### PR TITLE
docs: lab 2 spec, api, ui, and test plan

### DIFF
--- a/docs/lab-02/api-spec.md
+++ b/docs/lab-02/api-spec.md
@@ -1,0 +1,387 @@
+# Lab 2 API Contract
+
+All endpoints are relative to the existing Express app (`server/src/app.ts`).
+This document is normative for `tests.md`'s API-level tests; anything that
+disagrees with `specification.md` is a bug in one of the two documents,
+please flag it.
+
+## 0. Conventions Used Throughout
+
+### 0.1 Requester context (BR-10, BR-14, BR-15)
+
+There is no real authentication in Lab 2. Every Requester-scoped endpoint
+requires a `requesterId` identifying the current Development Requester,
+supplied by the client from its locally persisted selection:
+
+- On `GET` requests: query parameter `requesterId`.
+- On `POST`/`PATCH` requests: a `requesterId` field in the JSON (or
+  multipart) body.
+
+`GET /api/dev-requesters`, `GET /api/categories`, and
+`GET /api/related-systems` are reference-data endpoints and do not require
+`requesterId`.
+
+**Ownership rule**, applied identically everywhere: a Ticket or Attachment
+not owned by the supplied `requesterId` is treated exactly like a
+nonexistent one — the response is `404`, never `403`. This prevents an API
+consumer from learning that a given id exists but belongs to someone else.
+
+### 0.2 Standard error envelope
+
+```json
+{
+  "error": {
+    "code": "VALIDATION_ERROR",
+    "message": "Summary must be between 5 and 120 characters.",
+    "field": "summary"
+  }
+}
+```
+
+`field` is present only for a single-field validation failure. `code` is a
+stable machine-readable string (see per-endpoint tables); `message` is
+safe to show directly to the Requester.
+
+### 0.3 Status codes used in this contract
+
+| Status | Meaning here |
+| --- | --- |
+| 200 | Successful retrieval, or a mutation that doesn't create a new resource (soft-remove). |
+| 201 | Resource created (Ticket, Attachment). |
+| 400 | Invalid input: missing/malformed field, invalid enum value, unknown filter value, invalid Requester context. |
+| 404 | Resource not found, or found but not owned by the supplied `requesterId` (BR-15). |
+| 409 | Valid request, but rejected due to current resource state (5-active-attachment limit reached). |
+| 410 | Resource existed and is owned by the caller, but has been soft-removed (download of a removed Attachment). |
+| 413 | Uploaded file exceeds the 5 MB limit. |
+| 415 | Uploaded file's type is not one of JPG/JPEG/PNG/WEBP/PDF. |
+| 500 | Unexpected server error. Response body still uses the standard error envelope with `code: "INTERNAL_ERROR"` and a generic message — no stack traces or internals are exposed. |
+
+---
+
+## 1. `GET /api/dev-requesters`
+
+List active Development Requesters for the Selection screen.
+
+**Query params:** none.
+
+**200 response:**
+
+```json
+[
+  { "id": 1, "name": "Jennifer Anderson", "email": "jennifer.anderson@example.com" },
+  { "id": 2, "name": "Michael Brown", "email": "michael.brown@example.com" }
+]
+```
+
+Ordered by `name` ascending. Only rows with `isActive = true` are returned
+(BR-09); the seeded inactive Requester never appears here.
+
+**Failure:** `500` on unexpected DB error, safe error envelope, no partial
+list.
+
+---
+
+## 2. `GET /api/categories`
+
+List active Categories.
+
+**200 response:**
+
+```json
+[
+  { "id": 1, "name": "Account and Access" },
+  { "id": 2, "name": "Hardware" }
+]
+```
+
+Only `isActive = true` rows, ordered by `id` ascending (existing convention
+in `server/src/app.ts`).
+
+---
+
+## 3. `GET /api/related-systems`
+
+List active Related Systems. Same shape and ordering as `/api/categories`.
+
+```json
+[
+  { "id": 1, "name": "Email" },
+  { "id": 2, "name": "VPN" }
+]
+```
+
+---
+
+## 4. `POST /api/tickets`
+
+Create a Ticket for the current Requester (FR-02, FR-03).
+
+**Request body:**
+
+```json
+{
+  "requesterId": 1,
+  "categoryId": 2,
+  "relatedSystemId": 5,
+  "requestedPriority": "MEDIUM",
+  "summary": "Laptop battery drains quickly",
+  "description": "My laptop battery is draining much faster than usual even when the system is idle."
+}
+```
+
+| Field | Required | Rule |
+| --- | --- | --- |
+| `requesterId` | yes | Must reference an active `RequesterUser`. |
+| `categoryId` | yes | Must reference an active `Category`. |
+| `relatedSystemId` | yes | Must reference an active `RelatedSystem`. |
+| `requestedPriority` | yes | One of `LOW`, `MEDIUM`, `HIGH` (BR-08). |
+| `summary` | yes | Trimmed, 5–120 chars (BR-20). |
+| `description` | yes | Trimmed, 10–2000 chars (BR-21). |
+
+`ticketNumber`, `currentStatus`, `createdAt`, `updatedAt` are never accepted
+from the client — they are always server-generated (BR-01, BR-02, BR-04,
+BR-06).
+
+**201 response:**
+
+```json
+{
+  "id": 101,
+  "ticketNumber": "TKT-2026-000101",
+  "requesterId": 1,
+  "categoryId": 2,
+  "relatedSystemId": 5,
+  "requestedPriority": "MEDIUM",
+  "summary": "Laptop battery drains quickly",
+  "description": "My laptop battery is draining much faster than usual even when the system is idle.",
+  "currentStatus": "NEW",
+  "createdAt": "2026-09-01T09:14:00.000Z",
+  "updatedAt": "2026-09-01T09:14:00.000Z"
+}
+```
+
+**Failure cases:**
+
+| Status | `code` | Cause |
+| --- | --- | --- |
+| 400 | `VALIDATION_ERROR` | Missing/blank/out-of-range `summary`, `description`; missing `requestedPriority`. `field` identifies which. |
+| 400 | `INVALID_REFERENCE` | `categoryId`/`relatedSystemId` does not reference an active row. |
+| 400 | `INVALID_REQUESTER` | `requesterId` missing, unknown, or not active (BR-12) — client should return to the Selection screen. |
+| 500 | `INTERNAL_ERROR` | Unexpected error; no Ticket is persisted (AC-08). |
+
+No Attachment upload happens in this call — see §6 and BR-24/§11-12 of
+`specification.md`.
+
+---
+
+## 5. `GET /api/tickets`
+
+Search/filter/sort/paginate the current Requester's own Tickets (FR-05–09).
+
+**Query params:**
+
+| Param | Required | Notes |
+| --- | --- | --- |
+| `requesterId` | yes | Owner scope (BR-14). |
+| `search` | no | Case-insensitive partial match against `ticketNumber` OR `summary` (BR-16). |
+| `categoryId` | no | Exact match. Unknown/non-numeric id → `400`. |
+| `requestedPriority` | no | One of `LOW`/`MEDIUM`/`HIGH`. Unrecognized value → `400`. |
+| `status` | no | One of the `TicketStatus` enum values. Unrecognized value → `400`. |
+| `sortBy` | no | One of `createdAt`, `ticketNumber`, `summary`, `requestedPriority`, `currentStatus`. Default `createdAt`. Unrecognized value → `400`. |
+| `sortDir` | no | `asc` or `desc`. Default `desc`. Unrecognized value → `400`. |
+| `page` | no | 1-based integer. Default `1`. Non-positive or non-integer is clamped to `1` (BR-19), not rejected. |
+| `pageSize` | no | Integer, 1–50. Default `10`. Out-of-range is clamped to the nearest bound (BR-19). |
+
+Filters combine with AND logic (BR-17).
+
+**200 response:**
+
+```json
+{
+  "data": [
+    {
+      "id": 101,
+      "ticketNumber": "TKT-2026-000101",
+      "summary": "Laptop battery drains quickly",
+      "categoryId": 2,
+      "categoryName": "Hardware",
+      "requestedPriority": "MEDIUM",
+      "currentStatus": "NEW",
+      "createdAt": "2026-09-01T09:14:00.000Z",
+      "updatedAt": "2026-09-01T09:14:00.000Z"
+    }
+  ],
+  "page": 1,
+  "pageSize": 10,
+  "totalCount": 42,
+  "totalPages": 5,
+  "hasAnyTickets": true
+}
+```
+
+`hasAnyTickets` is the current Requester's **unfiltered** ticket count
+being greater than zero — the client uses it (together with `totalCount`)
+to distinguish the empty-account state (`hasAnyTickets: false`) from the
+no-results-for-these-filters state (`hasAnyTickets: true`, `totalCount: 0`)
+per BR-30/AC-19/AC-20.
+
+**Failure cases:**
+
+| Status | `code` | Cause |
+| --- | --- | --- |
+| 400 | `INVALID_REQUESTER` | `requesterId` missing, unknown, or not active. |
+| 400 | `INVALID_FILTER` | Unrecognized `requestedPriority`, `status`, `sortBy`, or `sortDir`; non-numeric `categoryId`. `field` identifies which. |
+| 500 | `INTERNAL_ERROR` | Unexpected error. |
+
+---
+
+## 6. `GET /api/tickets/:id`
+
+Retrieve one owned Ticket with full detail and its attachment list
+(FR-10).
+
+**Query params:** `requesterId` (required).
+
+**200 response:**
+
+```json
+{
+  "id": 101,
+  "ticketNumber": "TKT-2026-000101",
+  "requester": { "id": 1, "name": "Jennifer Anderson" },
+  "category": { "id": 2, "name": "Hardware" },
+  "relatedSystem": { "id": 5, "name": "Corporate Laptop" },
+  "requestedPriority": "MEDIUM",
+  "summary": "Laptop battery drains quickly",
+  "description": "My laptop battery is draining much faster than usual even when the system is idle.",
+  "currentStatus": "NEW",
+  "createdAt": "2026-09-01T09:14:00.000Z",
+  "updatedAt": "2026-09-01T09:14:00.000Z",
+  "attachments": [
+    {
+      "id": 501,
+      "originalFileName": "battery-report.pdf",
+      "mimeType": "application/pdf",
+      "sizeBytes": 812345,
+      "uploadedAt": "2026-09-01T09:15:00.000Z",
+      "isRemoved": false
+    },
+    {
+      "id": 502,
+      "originalFileName": "screenshot.png",
+      "mimeType": "image/png",
+      "sizeBytes": 245000,
+      "uploadedAt": "2026-08-30T10:00:00.000Z",
+      "isRemoved": true,
+      "removedAt": "2026-08-31T08:00:00.000Z"
+    }
+  ]
+}
+```
+
+Removed attachments are included (BR-28) but carry `isRemoved: true` and no
+downloadable content; the UI must not offer a download/preview action for
+them.
+
+**Failure cases:**
+
+| Status | `code` | Cause |
+| --- | --- | --- |
+| 400 | `INVALID_REQUESTER` | `requesterId` missing, unknown, or not active. |
+| 404 | `NOT_FOUND` | Ticket id doesn't exist, or exists but isn't owned by `requesterId` (BR-15/AC-03). |
+
+---
+
+## 7. `POST /api/tickets/:id/attachments`
+
+Upload an Attachment to an owned Ticket (FR-04). `multipart/form-data`.
+
+**Form fields:**
+
+| Field | Required | Notes |
+| --- | --- | --- |
+| `requesterId` | yes | Owner scope. |
+| `file` | yes | One file, ≤ 5 MB, type in `{jpg, jpeg, png, webp, pdf}` by extension and declared `Content-Type`. |
+
+**201 response:**
+
+```json
+{
+  "id": 503,
+  "ticketId": 101,
+  "originalFileName": "receipt.jpg",
+  "mimeType": "image/jpeg",
+  "sizeBytes": 1200000,
+  "uploadedAt": "2026-09-01T09:16:00.000Z",
+  "isRemoved": false
+}
+```
+
+**Failure cases:**
+
+| Status | `code` | Cause |
+| --- | --- | --- |
+| 400 | `INVALID_REQUESTER` | `requesterId` missing/unknown/inactive. |
+| 404 | `NOT_FOUND` | Ticket id doesn't exist or isn't owned by `requesterId`. |
+| 409 | `ATTACHMENT_LIMIT_REACHED` | Ticket already has 5 active Attachments (BR-26/AC-10). |
+| 413 | `FILE_TOO_LARGE` | File exceeds 5 MB (BR-25/AC-11). |
+| 415 | `UNSUPPORTED_FILE_TYPE` | Extension or content type not allowed (BR-25/AC-12). |
+| 500 | `INTERNAL_ERROR` | Storage or unexpected failure. The parent Ticket is unaffected either way (BR-24/AC-13). |
+
+---
+
+## 8. `GET /api/attachments/:id/download`
+
+Stream an active Attachment's file content (FR-11).
+
+**Query params:** `requesterId` (required).
+
+**200 response:** the raw file bytes, with `Content-Type` set to the
+stored `mimeType` and `Content-Disposition: attachment; filename="<originalFileName>"`.
+
+**Failure cases:**
+
+| Status | `code` | Cause |
+| --- | --- | --- |
+| 400 | `INVALID_REQUESTER` | `requesterId` missing/unknown/inactive. |
+| 404 | `NOT_FOUND` | Attachment id doesn't exist, or its Ticket isn't owned by `requesterId`. |
+| 410 | `ATTACHMENT_REMOVED` | Attachment exists and is owned by the caller, but `isRemoved = true` (BR-28/AC-15). |
+
+---
+
+## 9. `PATCH /api/attachments/:id/remove`
+
+Soft-remove an owned Attachment (FR-12).
+
+**Request body:**
+
+```json
+{ "requesterId": 1, "reason": "Wrong file, re-uploading the correct one" }
+```
+
+`reason` is optional (§11-2 of `specification.md`); omit or send an empty
+string when not provided.
+
+**200 response:** the updated Attachment, same shape as the upload
+response, now with `isRemoved: true`, `removedAt`, and `removedReason` (or
+`null` if none was given).
+
+Calling this on an Attachment that is **already** removed is idempotent —
+it returns `200` with the existing removed state rather than an error,
+since the caller's desired end state ("this attachment is removed") already
+holds.
+
+**Failure cases:**
+
+| Status | `code` | Cause |
+| --- | --- | --- |
+| 400 | `INVALID_REQUESTER` | `requesterId` missing/unknown/inactive. |
+| 404 | `NOT_FOUND` | Attachment id doesn't exist, or its Ticket isn't owned by `requesterId`. |
+
+---
+
+## 10. Traceability
+
+Every capability above is exercised by at least one planned test in
+`tests.md`'s AC-to-test matrix; see that document for the mapping from each
+endpoint/status-code case back to AC-01–AC-26.

--- a/docs/lab-02/specification.md
+++ b/docs/lab-02/specification.md
@@ -119,7 +119,7 @@ auth will build on top of — not a one-off.
 | BR-28 | A removed Attachment remains visible in the Ticket Detail attachment list as metadata (name, size, removed date) but cannot be downloaded or previewed; any download attempt for it fails safely. |
 | BR-29 | Uploading, downloading, and removing an Attachment are ownership-checked against the current Requester exactly like Ticket access (BR-14, BR-15). |
 | BR-30 | My Tickets shows an **empty** state (distinct from **no-results**) when the current Requester has zero Tickets in total, regardless of filters. It shows a **no-results** state when the Requester owns at least one Ticket but the current search/filter combination matches none. |
-| BR-31 | The Development Requester Selection screen and its "for testing only" messaging exist solely for Lab 2. Lab 3 replaces the selector with real authenticated sessions; Ticket ownership migrates from the temporary `RequesterUser` selection to the authenticated user without changing the meaning of the Ticket–Requester relationship. |
+| BR-31 | The Development Requester Selection screen and its "for testing only" messaging exist solely for Lab 2. Lab 3 replaces the selector with real authenticated sessions; Ticket ownership migrates from the temporary `RequesterUser` selection to the authenticated user without changing the meaning of the Ticket–Requester relationship. The implementation must resolve "current requester" through a single backend helper and a single frontend API-client wrapper (not inlined per endpoint/call site) so this swap touches two seams, not every request — see §11-1. |
 
 ## 6. UI Specification Summary
 
@@ -289,7 +289,13 @@ model Attachment {
 - **Lab 3 evolution**: `RequesterUser` is a placeholder for a future
   authenticated `User`/`Account` model. `Ticket.requesterId` is expected to
   be re-pointed (via migration) at the authenticated user's id without
-  changing its semantics — see BR-31.
+  changing its semantics — see BR-31. Only the *identification* step
+  (how the backend learns the current requester id, and how the frontend
+  supplies it) changes in Lab 3; the *ownership-check* logic (BR-14/BR-15)
+  is written generically against a requester id argument and needs no
+  change. That property only holds if identification is centralized behind
+  one backend helper and one frontend API-client wrapper rather than
+  inlined at every call site — see §11-1.
 
 ### 7.4 Required Seed Data
 
@@ -408,6 +414,19 @@ after the coding agent starts.
    alongside BR-03's warning not to build anything resembling real
    authentication — a server session is closer to real auth than a client-
    remembered id is.
+   **Lab 3 migration requirement**: this only stays a clean, low-cost swap
+   if *identification* ("who is asking?") is implemented behind a single
+   seam on each side — one backend helper (e.g. `getCurrentRequesterId(req)`)
+   that every route handler calls instead of reading `req.query`/`req.body`
+   directly, and one frontend API-client wrapper that every screen calls
+   instead of attaching `requesterId` ad hoc per request. *Authorization*
+   ("do they own this?", BR-14/BR-15) already takes a requester id as a
+   plain argument and doesn't care where it came from, so it needs no
+   change at all. Lab 3 then only replaces the two identification seams
+   (session/JWT-derived id instead of a trusted client-supplied one)
+   instead of touching every endpoint and every call site. The coding
+   agent must build to this seam, not inline the lookup — see BR-31 and
+   §7.3.
 2. **(reversible) Attachment removal reason is optional**, not required and
    not omitted. The stakeholder request never mentions an audit reason;
    optional keeps removal fast while still allowing one when it matters.

--- a/docs/lab-02/specification.md
+++ b/docs/lab-02/specification.md
@@ -1,0 +1,457 @@
+# Lab 2 Sprint Engineering Specification
+
+Status: **Draft — pending student review and approval before implementation.**
+Every interpretive call made while writing this document is called out in
+[§11 Assumptions and Decisions](#11-assumptions-and-decisions). Review that
+section first; correct anything that doesn't match intent before this
+contract is handed to the coding agent.
+
+## 1. Sprint Goal
+
+Deliver a Requester-facing ticketing experience — Create Ticket, My Tickets,
+Requester Ticket Detail, and the Attachment lifecycle (upload, download,
+soft-remove) — running against a temporary Development Requester identity
+that stands in for real login until Lab 3, all built on a reusable Zen Green
+UI foundation (forms, lists, badges, validation, loading, empty, error, and
+responsive conventions) that later labs can extend without redesign.
+
+## 2. Stakeholder Request Interpretation
+
+The IT department wants Requesters to self-serve: describe a problem,
+classify it (Category, Related System, Requested Priority), attach evidence,
+and submit — receiving a Requester-facing view of Category, Related System is
+required; and generate an official Ticket Number. Afterward, Requesters must
+be able to find their own tickets (search/filter), open a read-only Ticket
+Detail, and manage their own attachments — with a hard guarantee that one
+Requester can never see or touch another Requester's ticket.
+
+Because real login doesn't exist yet, the stakeholder wants a **temporary
+"pick who you are" screen** that simulates a logged-in Requester for testing
+purposes only, explicitly not to be confused with authentication. Everything
+built this sprint (visual language, form patterns, list/table patterns,
+states) is meant to be the reusable foundation IT Staff screens and Lab 3
+auth will build on top of — not a one-off.
+
+## 3. Scope
+
+### Included
+
+- Development Requester Selection screen (temporary "login," not real auth)
+- Create Ticket (Category, Related System, Requested Priority, Summary,
+  Description, Attachments)
+- My Tickets: Requester-owned ticket list with search, filter, sort,
+  pagination, empty state, no-results state
+- Requester Ticket Detail: read-only ticket fields + attachment management
+- Attachment lifecycle: upload (during creation or after), download
+  (active only), soft-remove
+- Ticket ownership enforcement (one Requester cannot view/act on another
+  Requester's data)
+- Zen Green visual system: color tokens, typography, field states, button
+  hierarchy, validation placement, responsive rules, accessibility basics
+- Seed data: 4 Categories, ≥6 Related Systems, ≥4 active Development
+  Requesters, ≥1 inactive Development Requester, sample Tickets across
+  multiple statuses for filter/sort demonstration
+
+### Excluded
+
+- Authentication, login, logout, passwords, sessions, tokens, real
+  role-based authorization (the Development Requester selector is a testing
+  mechanism only — BR-03)
+- IT Staff dashboard, ticket queue, claiming/reassigning, setting IT
+  Priority, or any other IT-Staff-owner function
+- Public Comments, Internal Notes, Actions Taken (ticket collaboration /
+  work tracking)
+- Status changes beyond the system-assigned initial `New` status —
+  resolution, closing, reopening, cancelling
+- Administrator functions (managing users, Requesters, roles, reference
+  data)
+
+## 4. Functional Requirements
+
+| ID | Requirement |
+| --- | --- |
+| FR-01 | The system shall provide a Development Requester Selection screen listing only active Requesters, letting the student choose one as the current testing context. |
+| FR-02 | The system shall let the current Requester create a Ticket by providing Category, Related System, Requested Priority, Summary, and Description. |
+| FR-03 | The system shall generate and display the official Ticket Number immediately after a Ticket is successfully created. |
+| FR-04 | The system shall let the current Requester attach up to 5 active supporting files to a Ticket, either during creation or afterward from Ticket Detail. |
+| FR-05 | The system shall list only the current Requester's own Tickets in My Tickets. |
+| FR-06 | The system shall let the current Requester search their Tickets by Ticket Number or Summary. |
+| FR-07 | The system shall let the current Requester filter their Tickets by Category, Requested Priority, and Current Status. |
+| FR-08 | The system shall let the current Requester sort their Tickets by Created Date, Ticket Number, Summary, Requested Priority, or Current Status. |
+| FR-09 | The system shall paginate My Tickets results with page/pageSize metadata. |
+| FR-10 | The system shall let the current Requester open a read-only Ticket Detail screen for any Ticket they own. |
+| FR-11 | The system shall let the current Requester download any active Attachment they own, and shall prevent downloading a removed Attachment. |
+| FR-12 | The system shall let the current Requester soft-remove an Attachment they own, optionally with a reason. |
+| FR-13 | The system shall let the current Requester switch to a different active Requester via a Change Requester action, reloading all Requester-scoped data. |
+| FR-14 | The system shall reject any attempt — via direct URL, forged request, or otherwise — to view or modify a Ticket or Attachment not owned by the current Requester. |
+
+## 5. Business Rules
+
+| BR ID | Business Rule |
+| --- | --- |
+| BR-01 | The official Ticket Number is generated by the backend and must be unique. |
+| BR-02 | A new Ticket begins with Current Status `New`. |
+| BR-03 | Lab 2 uses a Development Requester selector instead of login. The selected identity is for testing only and is not authentication. |
+| BR-04 | Ticket Date (`createdAt`) is system-generated at creation time; it is read-only and never entered by the Requester. |
+| BR-05 | The Requester field on Create Ticket is populated from the currently selected Development Requester and is read-only; it cannot be typed or changed on the form. |
+| BR-06 | The Ticket Number format is `TKT-<4-digit year>-<6-digit zero-padded sequence>` (e.g. `TKT-2026-000042`) and is not shown to the Requester until the Ticket is successfully created. |
+| BR-07 | Category and Related System must be chosen from the active, seeded reference lists; free-text values are not accepted. |
+| BR-08 | Requested Priority must be explicitly chosen from Low, Medium, or High; the field has no pre-selected default, and submission is blocked until a value is chosen. |
+| BR-09 | The Development Requester Selection screen lists only active (`isActive = true`) Requesters, ordered by name ascending. |
+| BR-10 | The selected Requester's identity is persisted client-side only (browser storage) for the duration of the browser session/device. It is not a server-side session and grants no trust beyond convenience — every API call must still carry the Requester's id explicitly. |
+| BR-11 | A "Change Requester" action is available from the application shell at all times; choosing a new Requester clears the previous Requester's client-side context and returns to the Development Requester Selection screen. |
+| BR-12 | If no Development Requester is currently selected — first visit, cleared storage, or the previously selected Requester is no longer active — any attempt to open My Tickets, Create Ticket, or Ticket Detail redirects to the Development Requester Selection screen. |
+| BR-13 | Every Ticket belongs to exactly one Requester (`Ticket.requesterId`), set once at creation from the currently selected Requester and never reassigned in Lab 2. |
+| BR-14 | A Requester may only retrieve, list, or act on Tickets and Attachments they own. The backend enforces this on every Requester-scoped endpoint regardless of what the client claims. |
+| BR-15 | An access attempt for a Ticket or Attachment owned by a different Requester returns a not-found response. The API must not reveal whether the resource exists but belongs to someone else versus not existing at all (prevents ID enumeration). |
+| BR-16 | My Tickets search matches Ticket Number or Summary, case-insensitive, partial match, scoped to the current Requester's own tickets only. |
+| BR-17 | My Tickets supports filtering by Category, Requested Priority, and Current Status; combined filters narrow results with AND logic. |
+| BR-18 | My Tickets supports sorting by Created Date, Ticket Number, Summary, Requested Priority, and Current Status, ascending or descending. Default sort is Created Date descending (newest first). |
+| BR-19 | My Tickets is paginated. Default page size is 10; maximum page size is 50. Out-of-range `page`/`pageSize` values are clamped to the nearest valid value rather than rejected. |
+| BR-20 | Ticket Summary is required, trimmed of leading/trailing whitespace, and must be 5–120 characters after trimming. |
+| BR-21 | Ticket Description is required, trimmed, and must be 10–2000 characters after trimming. |
+| BR-22 | The Create Ticket Submit control is disabled while a request is in flight, preventing a duplicate Ticket from a repeated click on the same submission. |
+| BR-23 | If Ticket creation fails (validation or server error), no Ticket is persisted and the Requester's entered field values remain in the form so nothing needs retyping. |
+| BR-24 | If a Ticket is created successfully but a selected Attachment fails to upload (size, type, count limit, or transient failure), the Ticket is **not** rolled back. The Requester sees a per-file error for the failed upload(s) and can retry from Ticket Detail; successfully uploaded files remain attached. |
+| BR-25 | Attachments accept only JPG, JPEG, PNG, WEBP, and PDF files (checked by file extension and declared content type), each at most 5 MB. |
+| BR-26 | A Ticket may have at most 5 active (non-removed) Attachments at a time. Upload is rejected once the limit is reached until an existing Attachment is removed. |
+| BR-27 | Removing an Attachment is a soft removal: the Attachment row is kept with `isRemoved = true`, `removedAt`, and an optional `removedReason`. The underlying file is not deleted from storage. |
+| BR-28 | A removed Attachment remains visible in the Ticket Detail attachment list as metadata (name, size, removed date) but cannot be downloaded or previewed; any download attempt for it fails safely. |
+| BR-29 | Uploading, downloading, and removing an Attachment are ownership-checked against the current Requester exactly like Ticket access (BR-14, BR-15). |
+| BR-30 | My Tickets shows an **empty** state (distinct from **no-results**) when the current Requester has zero Tickets in total, regardless of filters. It shows a **no-results** state when the Requester owns at least one Ticket but the current search/filter combination matches none. |
+| BR-31 | The Development Requester Selection screen and its "for testing only" messaging exist solely for Lab 2. Lab 3 replaces the selector with real authenticated sessions; Ticket ownership migrates from the temporary `RequesterUser` selection to the authenticated user without changing the meaning of the Ticket–Requester relationship. |
+
+## 6. UI Specification Summary
+
+Full detail lives in [`ui-spec.md`](./ui-spec.md). Summary:
+
+- **Application shell**: TokTickIT identity, My Tickets / Create Ticket nav,
+  current Requester display + Change Requester action, active-page
+  indication, responsive mobile navigation.
+- **Development Requester Selection**: dropdown of active Requesters,
+  "testing only, not login" messaging, loading/empty/API-failure states,
+  keyboard-accessible controls.
+- **Create Ticket**: system-generated fields visually distinct and
+  read-only (Ticket Number shown only after success, Ticket Date, Requester);
+  classification fields grouped (Category, Related System, Requested
+  Priority); Summary/Description given full width; Attachments below the
+  main fields; primary (Submit) + secondary (Cancel) actions at the bottom;
+  field-level validation messages; busy Submit state; success state showing
+  the generated Ticket Number.
+- **My Tickets**: search box, Category/Priority/Status filters, Clear
+  Filters, Create Ticket action, sortable columns, pagination, desktop table
+  / mobile card representation, empty vs no-results states, badge styling
+  for Requested Priority and Current Status.
+- **Requester Ticket Detail**: all Ticket fields read-only, grouped
+  separately from the Attachment section; Attachment list shows
+  active/removed state, upload control (disabled at the 5-attachment cap),
+  download action (active only), remove action with confirmation.
+- All screens follow the Zen Green tokens in §7 of the handout (reproduced
+  in `ui-spec.md`) and the responsive rules (desktop ≥ 992px, tablet
+  768–991px, mobile < 768px — no horizontal scrolling at any size).
+
+## 7. Data Changes
+
+New PostgreSQL concepts required by this sprint: `RequesterUser`, `Ticket`,
+`Attachment`, `RelatedSystem`, plus additive changes to the existing
+`Category` model. This section documents the target design; it is **not**
+applied to `server/prisma/schema.prisma` by this specification task — that
+happens in the implementation phase.
+
+### 7.1 Relationships
+
+- One `RequesterUser` owns many `Ticket`s (1:N).
+- One `Ticket` belongs to exactly one `RequesterUser` (N:1).
+- One `Ticket` may have many `Attachment`s (1:N).
+- One `Category` may be used by many `Ticket`s (1:N).
+- One `RelatedSystem` may be used by many `Ticket`s (1:N).
+
+### 7.2 Target Prisma Schema
+
+```prisma
+model RequesterUser {
+  id        Int      @id @default(autoincrement())
+  name      String
+  email     String   @unique
+  isActive  Boolean  @default(true)
+  createdAt DateTime @default(now())
+
+  tickets Ticket[]
+}
+
+model Category {
+  id        Int      @id @default(autoincrement())
+  name      String   @unique
+  isActive  Boolean  @default(true)
+  createdAt DateTime @default(now())
+
+  tickets Ticket[]
+}
+
+model RelatedSystem {
+  id        Int      @id @default(autoincrement())
+  name      String   @unique
+  isActive  Boolean  @default(true)
+  createdAt DateTime @default(now())
+
+  tickets Ticket[]
+}
+
+enum RequestedPriority {
+  LOW
+  MEDIUM
+  HIGH
+}
+
+enum TicketStatus {
+  NEW
+  OPEN
+  IN_PROGRESS
+  PENDING
+  RESOLVED
+  CLOSED
+  CANCELLED
+}
+
+model Ticket {
+  id                Int               @id @default(autoincrement())
+  ticketNumber      String            @unique
+  requesterId       Int
+  requester         RequesterUser     @relation(fields: [requesterId], references: [id])
+  categoryId        Int
+  category          Category          @relation(fields: [categoryId], references: [id])
+  relatedSystemId   Int
+  relatedSystem     RelatedSystem     @relation(fields: [relatedSystemId], references: [id])
+  summary           String
+  description       String
+  requestedPriority RequestedPriority
+  currentStatus     TicketStatus      @default(NEW)
+  createdAt         DateTime          @default(now())
+  updatedAt         DateTime          @updatedAt
+
+  attachments Attachment[]
+
+  @@index([requesterId])
+  @@index([categoryId])
+  @@index([relatedSystemId])
+  @@index([currentStatus])
+  @@index([createdAt])
+}
+
+model Attachment {
+  id               Int       @id @default(autoincrement())
+  ticketId         Int
+  ticket           Ticket    @relation(fields: [ticketId], references: [id])
+  originalFileName String
+  storedFileName   String    @unique
+  mimeType         String
+  sizeBytes        Int
+  uploadedAt       DateTime  @default(now())
+  isRemoved        Boolean   @default(false)
+  removedAt        DateTime?
+  removedReason    String?
+
+  @@index([ticketId])
+  @@index([ticketId, isRemoved])
+}
+```
+
+### 7.3 Design Notes and Justification
+
+- **`ticketNumber` uniqueness (BR-01, BR-06)**: generated from the row's own
+  autoincrementing `id` immediately after insert (`TKT-<year>-<id padded to
+  6 digits>`), avoiding a separately-tracked counter that could race under
+  concurrent creates.
+- **`isActive` added to `Category`**: the API contract requires "retrieve
+  active Categories" (handout §6), which only makes sense if a Category can
+  be inactive. This is an additive, backward-compatible column on the
+  existing model.
+- **`RelatedSystem` mirrors `Category`'s shape** (id, name, isActive,
+  createdAt) since both are simple, admin-managed reference lists with
+  identical required behavior (active-only retrieval, unique name).
+- **`TicketStatus` includes values beyond `New`** (Open, In Progress,
+  Pending, Resolved, Closed, Cancelled) even though Lab 2 never writes any
+  value other than `NEW` through its own APIs. The My Tickets screen must
+  support filtering/sorting/badges by Current Status (handout Fig. on p.11
+  shows multiple statuses), so seed data populates other statuses directly;
+  no Lab 2 endpoint transitions a Ticket's status.
+- **Soft removal on `Attachment`** (`isRemoved`, `removedAt`,
+  `removedReason`) instead of deleting the row, per BR-27/BR-28 — the row
+  and its metadata must remain visible after removal.
+- **No IT-Staff-only columns** (IT Priority, Ticket Owner, Resolution
+  Summary) are added in Lab 2. See §11 for rationale.
+- **Indexes**: FK columns (`requesterId`, `categoryId`, `relatedSystemId`,
+  `ticketId`) are indexed for join/filter performance; `currentStatus` and
+  `createdAt` are indexed because My Tickets filters and sorts by them by
+  default. Search (`search` query param against `ticketNumber`/`summary`)
+  uses a case-insensitive `ILIKE` scan with no dedicated text index — see
+  Known Limitations in `tests.md`; acceptable at Lab 2's seed-data scale.
+- **Lab 3 evolution**: `RequesterUser` is a placeholder for a future
+  authenticated `User`/`Account` model. `Ticket.requesterId` is expected to
+  be re-pointed (via migration) at the authenticated user's id without
+  changing its semantics — see BR-31.
+
+### 7.4 Required Seed Data
+
+- 4 Categories: Account and Access, Hardware, Software, Network
+- ≥ 6 Related Systems: Email, Campus Wi-Fi, VPN, LEB2 App, Grade Submission
+  App, Printer, Corporate Laptop
+- ≥ 4 active `RequesterUser` rows with realistic names/emails
+- ≥ 1 inactive `RequesterUser` row (must never appear in the Development
+  Requester Selection dropdown)
+- A spread of seeded Tickets per active Requester, including: enough for
+  at least one Requester to exceed one page at the default page size (to
+  exercise pagination), at least one Requester with zero Tickets (to
+  exercise the empty state), and Tickets across multiple `TicketStatus` and
+  `RequestedPriority` values (to exercise filters, sorting, and badges)
+- Seed logic is idempotent (safe to run repeatedly without duplicating
+  rows), consistent with the existing `prisma/seed.ts` `upsert` pattern
+
+## 8. API Contract
+
+Full detail lives in [`api-spec.md`](./api-spec.md). Endpoint summary:
+
+| Method | Path | Purpose |
+| --- | --- | --- |
+| GET | `/api/dev-requesters` | List active Development Requesters |
+| GET | `/api/categories` | List active Categories |
+| GET | `/api/related-systems` | List active Related Systems |
+| POST | `/api/tickets` | Create a Ticket for the current Requester |
+| GET | `/api/tickets` | Search/filter/sort/paginate the current Requester's Tickets |
+| GET | `/api/tickets/:id` | Retrieve one owned Ticket, with its attachments |
+| POST | `/api/tickets/:id/attachments` | Upload an Attachment to an owned Ticket |
+| GET | `/api/attachments/:id/download` | Download an active, owned Attachment |
+| PATCH | `/api/attachments/:id/remove` | Soft-remove an owned Attachment |
+
+Every endpoint above except the three reference-data `GET`s requires the
+current Requester's id (BR-10) and enforces ownership per BR-14/BR-15.
+
+## 9. Acceptance Criteria
+
+| ID | Criterion |
+| --- | --- |
+| AC-01 | Given valid Ticket data, when the Requester submits the form, then one Ticket is saved and the official Ticket Number is displayed. |
+| AC-02 | Given no Development Requester is selected, when the user attempts to open My Tickets, then the Development Requester Selection screen is shown. |
+| AC-03 | Given Requester B is selected, when a Ticket belonging to Requester A is requested, then the Ticket data is not returned. |
+| AC-04 | Given the Create Ticket form is submitted without a Summary, when validation runs, then a field-level error appears under Summary and no request is sent to the API. |
+| AC-05 | Given the Create Ticket form is submitted with a Description shorter than 10 characters, when validation runs, then a field-level error appears under Description and no Ticket is created. |
+| AC-06 | Given no Requested Priority is chosen, when the Requester submits, then a field-level error appears under Requested Priority and no Ticket is created. |
+| AC-07 | Given the Requester clicks Submit twice in quick succession, when the first request is still in flight, then only one Ticket is created and the button shows a disabled/busy state. |
+| AC-08 | Given the backend rejects Ticket creation with a server error, when the failure response is received, then the entered field values remain visible and a safe error message is shown, with no Ticket created. |
+| AC-09 | Given a Ticket was just created, when the Requester attaches a valid 2 MB JPG, then the Attachment is stored, appears in the active attachment list, and counts toward the 5-attachment limit. |
+| AC-10 | Given a Ticket already has 5 active Attachments, when the Requester attempts to upload a 6th file, then the upload is rejected with a limit-reached message and no 6th Attachment is stored. |
+| AC-11 | Given the Requester selects a 6 MB PDF, when upload is attempted, then it is rejected with a file-size error and no Attachment row is created. |
+| AC-12 | Given the Requester selects a `.exe` file, when upload is attempted, then it is rejected with an unsupported-file-type error and no Attachment row is created. |
+| AC-13 | Given a Ticket was created but one selected Attachment failed to upload, when the Requester views the result, then the Ticket exists with its official Ticket Number, the failed file shows a retryable error, and any other successfully uploaded files remain attached. |
+| AC-14 | Given an active Attachment, when the Requester removes it and confirms, then it is marked removed, disappears from the downloadable list, but still appears in the attachment list as removed metadata. |
+| AC-15 | Given a removed Attachment, when a download is attempted directly, then the request fails safely and no file is returned. |
+| AC-16 | Given the current Requester has Tickets whose Summary contains "VPN", when they search "vpn" in My Tickets, then only matching Tickets (case-insensitive) are shown. |
+| AC-17 | Given the current Requester filters My Tickets by Category = Hardware and Current Status = Open, when the filters are applied, then only Tickets matching both conditions are shown. |
+| AC-18 | Given the current Requester has more Tickets than one page, when they open My Tickets, then only the first page is shown along with correct pagination controls and total counts. |
+| AC-19 | Given the current Requester's filtered results are empty but they own at least one Ticket overall, when My Tickets renders, then a no-results state with a Clear Filters action is shown, not the empty-account state. |
+| AC-20 | Given the current Requester owns zero Tickets, when My Tickets renders with no filters applied, then an empty state inviting them to create their first Ticket is shown. |
+| AC-21 | Given the Development Requester Selection screen loads, when the active-Requesters request fails, then a safe error state is shown with no dropdown crash. |
+| AC-22 | Given the seeded inactive Requester, when the Development Requester Selection dropdown is loaded, then the inactive Requester does not appear in the list. |
+| AC-23 | Given a Requester is selected, when they use Change Requester and pick a different Requester, then the previous Requester's ticket data no longer appears anywhere in the app. |
+| AC-24 | Given a Ticket owned by the current Requester, when they open its Ticket Detail screen, then all Ticket fields render read-only with no editable Status, IT Priority, or Comment controls. |
+| AC-25 | Given the viewport is narrowed to mobile width, when My Tickets, Create Ticket, and Ticket Detail are viewed, then no horizontal scrolling occurs and all controls remain reachable and legible. |
+| AC-26 | Given a required field is left empty, when its error message renders, then it appears immediately below that field, not only in a page-level summary. |
+
+## 10. Definition of Done
+
+### Product Completion
+
+- [ ] All scoped screens implemented: Development Requester Selection,
+      Create Ticket, My Tickets, Requester Ticket Detail, Attachment
+      lifecycle (upload/download/soft-remove)
+- [ ] Every acceptance criterion (AC-01–AC-26) has passing, traceable
+      automated test evidence per `tests.md`
+- [ ] No required test is skipped, disabled, or commented out
+- [ ] Ownership isolation (BR-14/BR-15) is verified by at least one
+      automated test per Requester-scoped endpoint
+- [ ] Attachment constraints (type, size, count, soft removal) match §4.5
+      of the handout and BR-25–BR-29 exactly
+- [ ] Implemented screens and APIs conform to `ui-spec.md` and
+      `api-spec.md`
+- [ ] Zen Green tokens match §7 of the handout; responsive rules (desktop /
+      tablet / mobile) hold with no clipping, overlap, or horizontal
+      scrolling
+- [ ] Success, failure, validation, loading, empty, and no-results states
+      are implemented and covered by tests for every screen that needs them
+- [ ] `README.md` setup and test instructions are current
+- [ ] All required tests pass from documented commands on the final `main`
+      branch
+
+### Course Delivery Requirements (checked separately from Product Completion)
+
+- [ ] Work delivered via GitHub Issues and feature branches into
+      `lab2-staging`, then one release Pull Request into `main`
+- [ ] Peer review completed and recorded in `reviewer.md`
+- [ ] Review comments addressed
+- [ ] Required repository documents present: `specification.md`,
+      `tests.md`, `ui-spec.md`, `api-spec.md`, `reviewer.md`, `ai-use.md`
+- [ ] Submission PDF assembled per the handout's Part 1–9 format
+
+## 11. Assumptions and Decisions
+
+Every item below is an interpretation this specification made where the
+handout left the choice to the student. Review each one; anything marked
+**(reversible)** is cheap to change before implementation, anything marked
+**(structural)** touches the API/schema shape and is more costly to change
+after the coding agent starts.
+
+1. **(structural) Requester-context transport.** The client persists the
+   selected `requesterId` in browser storage and sends it explicitly on
+   every API call (query param on GETs, body field on mutations) rather
+   than a server-side pseudo-session cookie. Derived from the stakeholder
+   text ("the selected Requester becomes the current testing context") read
+   alongside BR-03's warning not to build anything resembling real
+   authentication — a server session is closer to real auth than a client-
+   remembered id is.
+2. **(reversible) Attachment removal reason is optional**, not required and
+   not omitted. The stakeholder request never mentions an audit reason;
+   optional keeps removal fast while still allowing one when it matters.
+3. **(structural) No IT-Staff-only columns in the Lab 2 schema** (IT
+   Priority, Ticket Owner, Resolution Summary). Directly supported by
+   §4.2 (IT Staff workflow excluded) and §5 (required concepts list omits
+   them). They arrive via a Lab 3/4 migration instead of being pre-built
+   nullable columns now.
+4. **(reversible) Ticket Number format**: `TKT-<year>-<6-digit id>`,
+   matching the illustrative screenshot's shape (`TKT-2025-001234`).
+5. **(structural) Ownership failures return 404, not 403.** Chosen so the
+   API never confirms that a Ticket/Attachment exists but belongs to
+   someone else (BR-15) — a 403 would leak that information.
+6. **(structural) Attachment storage is local disk** under a
+   `server`-relative, gitignored uploads directory, with a random stored
+   filename (collision/path-traversal-safe) and the original filename kept
+   only as a display column. No cloud/object storage is introduced for this
+   lab-scale MVP.
+7. **(reversible) Requested Priority has no default** — the Requester must
+   actively choose Low/Medium/High. Priority materially affects triage, so
+   silently defaulting it felt wrong; happy to switch to a Medium default if
+   preferred.
+8. **(reversible) `TicketStatus` enum includes values beyond `New`**
+   (Open, In Progress, Pending, Resolved, Closed, Cancelled) purely so seed
+   data can populate My Tickets with realistic filter/sort/badge variety, as
+   shown in the handout's example screenshot. No Lab 2 endpoint ever writes
+   a status other than `NEW`.
+9. **(reversible) Pagination defaults**: page size 10 (default) / 50 (max),
+   1-based `page`, out-of-range values clamped rather than rejected —
+   friendlier UX for a stray or stale query string. Full contract is in
+   `api-spec.md`.
+10. **(reversible) Duplicate-submission prevention is client-side only**
+    (disabled/busy Submit button); no server-side idempotency key. Adequate
+    for this lab's realistic concurrency; noted as a documented limitation
+    in `tests.md` with an upgrade path if it ever matters.
+11. **(reversible) Field length limits**: Summary 5–120 characters,
+    Description 10–2000 characters, both trimmed. Chosen as reasonable
+    bounds for a support-ticket form; not specified by the handout.
+12. **(structural) Attachment upload and Ticket creation are separate API
+    calls.** The Create Ticket screen presents them together, but the
+    client creates the Ticket first, then uploads each selected file
+    against the new Ticket's id. This is what makes "behavior when a Ticket
+    is created but attachment upload fails" (handout §4.5) a real,
+    definable scenario — see BR-24.
+13. **(reversible) Search has no dedicated text index** — case-insensitive
+    `ILIKE` against `ticketNumber`/`summary`. Fine at seed-data scale;
+    called out as a known limitation rather than a premature optimization.

--- a/docs/lab-02/tests.md
+++ b/docs/lab-02/tests.md
@@ -1,0 +1,195 @@
+# Lab 2 Test Plan and Results
+
+This plan is written from `specification.md` and `api-spec.md` before any
+implementation code exists (Test DD — see handout §9). It is the contract
+the coding agent must satisfy; it is not to be reconstructed afterward from
+whatever tests happen to get generated.
+
+## 1. Test Strategy
+
+- **Unit** — pure logic with no DB/HTTP: Ticket Number formatting,
+  attachment filename/type validation, Requester-context resolution rules.
+  Vitest, colocated under `server/tests/lab-02/`.
+- **API / integration** — Supertest against the Express app with a real
+  test database, one file per resource area, matching the required minimum
+  structure (handout §12). Covers every endpoint, status code, and
+  ownership rule in `api-spec.md`.
+- **UI component** — Vitest + Testing Library, one file per screen/major
+  component under `client/tests/lab-02/`, following the existing Lab 1
+  convention of tests living in `tests/`, not next to source.
+- **UI style / responsive / visual** — Playwright, asserting required CSS
+  classes/field states plus screenshots at desktop/tablet/mobile viewports,
+  checked against `ui-spec.md` §12 rather than personal judgment.
+- **E2E** — Playwright, full user flows spanning Requester selection →
+  ticket creation → My Tickets → Ticket Detail → attachment lifecycle,
+  including cross-Requester isolation.
+
+Every row in §2 traces to at least one Acceptance Criterion, Business Rule,
+or Functional Requirement in `specification.md`. Every Acceptance Criterion
+is covered by at least one row (§3 matrix).
+
+## 2. Planned Tests
+
+| Test ID | Type | Requirement / AC | What It Tests | Expected Result | Automated Test File | Final |
+| --- | --- | --- | --- | --- | --- | --- |
+| UNIT-01 | Unit | BR-06, AC-01 | Ticket Number generator | Returns `TKT-<year>-<6-digit>` from a given id/year | `server/tests/lab-02/ticket-number.unit.test.ts` | Planned |
+| UNIT-02 | Unit | BR-25 | Attachment filename/type validator | Accepts jpg/jpeg/png/webp/pdf, rejects everything else and path-unsafe names | `server/tests/lab-02/attachment-filename.unit.test.ts` | Planned |
+| UNIT-03 | Unit | BR-10, BR-12 | Requester-context resolver | Rejects a `requesterId` that is missing, unknown, or inactive | `server/tests/lab-02/requester-context.unit.test.ts` | Planned |
+| API-01 | API | AC-01 | `POST /api/tickets` valid body | 201; one row saved; response includes `ticketNumber` | `server/tests/lab-02/create-ticket.api.test.ts` | Planned |
+| API-02 | API | AC-04 | `POST /api/tickets` missing summary | 400 `VALIDATION_ERROR` field `summary`; no row inserted | `server/tests/lab-02/create-ticket.api.test.ts` | Planned |
+| API-03 | API | AC-05 | `POST /api/tickets` description < 10 chars | 400 `VALIDATION_ERROR` field `description`; no row inserted | `server/tests/lab-02/create-ticket.api.test.ts` | Planned |
+| API-04 | API | AC-06 | `POST /api/tickets` missing `requestedPriority` | 400 `VALIDATION_ERROR` field `requestedPriority` | `server/tests/lab-02/create-ticket.api.test.ts` | Planned |
+| API-05 | API | BR-12 | `POST /api/tickets` inactive/unknown `requesterId` | 400 `INVALID_REQUESTER`; no row inserted | `server/tests/lab-02/create-ticket.api.test.ts` | Planned |
+| API-06 | API | AC-03 | `GET /api/tickets` cross-Requester scope | Requester B's list never includes Requester A's tickets | `server/tests/lab-02/my-tickets.api.test.ts` | Planned |
+| API-07 | API | AC-16 | `GET /api/tickets?search=vpn` | Case-insensitive partial match on `ticketNumber`/`summary` only | `server/tests/lab-02/my-tickets.api.test.ts` | Planned |
+| API-08 | API | AC-17 | `GET /api/tickets?categoryId=&status=` | AND-combined filters return only matching rows | `server/tests/lab-02/my-tickets.api.test.ts` | Planned |
+| API-09 | API | AC-18 | `GET /api/tickets` pagination metadata | Correct `page`/`pageSize`/`totalCount`/`totalPages` | `server/tests/lab-02/my-tickets.api.test.ts` | Planned |
+| API-10 | API | BR-19 | `GET /api/tickets` out-of-range `page`/`pageSize` | Clamped to valid bounds, not rejected | `server/tests/lab-02/my-tickets.api.test.ts` | Planned |
+| API-11 | API | AC-20 | `GET /api/tickets` for a Requester with zero tickets | `data: []`, `hasAnyTickets: false` | `server/tests/lab-02/my-tickets.api.test.ts` | Planned |
+| API-12 | API | AC-19 | `GET /api/tickets` filters matching nothing | `data: []`, `hasAnyTickets: true`, `totalCount: 0` | `server/tests/lab-02/my-tickets.api.test.ts` | Planned |
+| API-13 | API | AC-24 | `GET /api/tickets/:id` owned | 200 with full detail + attachments | `server/tests/lab-02/ticket-detail.api.test.ts` | Planned |
+| API-14 | API | AC-03 | `GET /api/tickets/:id` not owned | 404 `NOT_FOUND` (not 403) | `server/tests/lab-02/ticket-detail.api.test.ts` | Planned |
+| API-15 | API | AC-09 | `POST /api/tickets/:id/attachments` valid 2MB jpg | 201; appears in active attachment list | `server/tests/lab-02/attachments.api.test.ts` | Planned |
+| API-16 | API | AC-10 | Upload at 5-active-attachment cap | 409 `ATTACHMENT_LIMIT_REACHED`; no 6th row | `server/tests/lab-02/attachments.api.test.ts` | Planned |
+| API-17 | API | AC-11 | Upload 6MB pdf | 413 `FILE_TOO_LARGE`; no row created | `server/tests/lab-02/attachments.api.test.ts` | Planned |
+| API-18 | API | AC-12 | Upload `.exe` | 415 `UNSUPPORTED_FILE_TYPE`; no row created | `server/tests/lab-02/attachments.api.test.ts` | Planned |
+| API-19 | API | FR-11 | `GET /api/attachments/:id/download` active | 200, correct `Content-Type`/`Content-Disposition`, byte-identical to upload | `server/tests/lab-02/attachments.api.test.ts` | Planned |
+| API-20 | API | AC-15 | Download a removed attachment | 410 `ATTACHMENT_REMOVED`; no file returned | `server/tests/lab-02/attachments.api.test.ts` | Planned |
+| API-21 | API | AC-14 | `PATCH /api/attachments/:id/remove` | 200; `isRemoved: true`, `removedAt` set, row retained | `server/tests/lab-02/attachments.api.test.ts` | Planned |
+| API-22 | API | BR-29 | Remove an attachment not owned by caller | 404 `NOT_FOUND` | `server/tests/lab-02/attachments.api.test.ts` | Planned |
+| API-23 | API | AC-13 | Attachment upload fails after Ticket creation succeeds | Ticket row still exists unmodified; only the attachment call fails | `server/tests/lab-02/attachments.api.test.ts` | Planned |
+| API-24 | API | AC-22 | `GET /api/dev-requesters` | Only `isActive: true` rows, ordered by name | `server/tests/lab-02/dev-requesters.api.test.ts` | Planned |
+| API-25 | API | FR-02 (ref data) | `GET /api/categories`, `GET /api/related-systems` | Only active rows returned | `server/tests/lab-02/dev-requesters.api.test.ts` | Planned |
+| UI-01 | UI | AC-22 | DevRequesterSelection active-list rendering | Inactive seeded Requester never appears; Continue disabled until chosen | `client/tests/lab-02/DevRequesterSelection.test.tsx` | Planned |
+| UI-02 | UI | AC-21 | DevRequesterSelection API failure | Safe error state shown, no crash, no dropdown left in a broken state | `client/tests/lab-02/DevRequesterSelection.test.tsx` | Planned |
+| UI-03 | UI | AC-02 | Opening My Tickets/Create Ticket/Ticket Detail with no stored Requester | Redirects to Development Requester Selection | `client/tests/lab-02/DevRequesterSelection.test.tsx` | Planned |
+| UI-04 | UI | AC-23 | Change Requester flow | Previous Requester's ticket data is gone after switching | `client/tests/lab-02/DevRequesterSelection.test.tsx` | Planned |
+| UI-05 | UI | AC-04, AC-26 | CreateTicket blank Summary | Field-level error directly under Summary; API not called | `client/tests/lab-02/CreateTicket.test.tsx` | Planned |
+| UI-06 | UI | AC-07 | CreateTicket double-submit | Submit shows Busy/disabled state; only one API call fires | `client/tests/lab-02/CreateTicket.test.tsx` | Planned |
+| UI-07 | UI | AC-08 | CreateTicket server failure | Entered values preserved; safe error banner shown | `client/tests/lab-02/CreateTicket.test.tsx` | Planned |
+| UI-08 | UI | AC-01 | CreateTicket success | Generated Ticket Number shown in success state | `client/tests/lab-02/CreateTicket.test.tsx` | Planned |
+| UI-09 | UI | AC-11 | CreateTicket oversized file, client-side | Per-file error shown before any upload request fires | `client/tests/lab-02/CreateTicket.test.tsx` | Planned |
+| UI-10 | UI | AC-20 | MyTickets empty state | Empty-account copy + Create Ticket CTA, no filter UI implying data exists | `client/tests/lab-02/MyTickets.test.tsx` | Planned |
+| UI-11 | UI | AC-19 | MyTickets no-results state | No-results copy + Clear Filters, distinct from empty state | `client/tests/lab-02/MyTickets.test.tsx` | Planned |
+| UI-12 | UI | AC-18 | MyTickets pagination controls | Page navigation updates the list and the "Showing X to Y of Z" text | `client/tests/lab-02/MyTickets.test.tsx` | Planned |
+| UI-13 | UI | AC-16 | MyTickets search input | List filters as the Requester types a search term | `client/tests/lab-02/MyTickets.test.tsx` | Planned |
+| UI-14 | UI | AC-24 | RequesterTicketDetail read-only rendering | All Ticket fields read-only; no Comment/Status/IT Priority controls present | `client/tests/lab-02/RequesterTicketDetail.test.tsx` | Planned |
+| UI-15 | UI | AC-14, AC-15 | AttachmentSection active vs removed | Active shows Download; removed shows metadata only, no Download action | `client/tests/lab-02/AttachmentSection.test.tsx` | Planned |
+| UI-16 | UI | AC-10 | AttachmentSection at the 5-attachment cap | Upload control shows disabled state with limit explanation | `client/tests/lab-02/AttachmentSection.test.tsx` | Planned |
+| STYLE-01 | UI style | ui-spec.md §3–4 | CreateTicket field/button classes | Required CSS classes/tokens present for editable, read-only, invalid, disabled, busy states | `client/tests/lab-02/CreateTicket.test.tsx` | Planned |
+| STYLE-02 | Visual/Responsive | AC-25 | Create Ticket screenshots | Desktop/tablet/mobile screenshots match `ui-spec.md`, no clipping/overlap/scroll | `e2e/lab-02/requester-ticket-flow.spec.ts` → `artifacts/lab-02/screenshots/create-ticket/` | Planned |
+| STYLE-03 | Visual/Responsive | AC-25 | My Tickets screenshots | Desktop table vs. mobile card, no horizontal scroll | `e2e/lab-02/requester-ticket-flow.spec.ts` → `artifacts/lab-02/screenshots/my-tickets/` | Planned |
+| STYLE-04 | Visual/Responsive | AC-25 | Ticket Detail screenshots | All three viewports legible, no clipping/overlap | `e2e/lab-02/requester-ticket-flow.spec.ts` → `artifacts/lab-02/screenshots/ticket-detail/` | Planned |
+| E2E-01 | E2E | AC-01, AC-09, AC-16, AC-24 | Full create → find → open flow | Select Requester, create ticket w/ attachment, find via search in My Tickets, open Ticket Detail and confirm data + attachment | `e2e/lab-02/requester-ticket-flow.spec.ts` | Planned |
+| E2E-02 | E2E | AC-03, AC-23 | Cross-Requester isolation | Requester A's ticket invisible to Requester B in list and direct navigation | `e2e/lab-02/requester-ticket-flow.spec.ts` | Planned |
+| E2E-03 | E2E | AC-14, AC-15 | Attachment lifecycle | Upload → download succeeds → soft-remove → download now fails safely | `e2e/lab-02/requester-ticket-flow.spec.ts` | Planned |
+
+## 3. Acceptance-Criterion Traceability Matrix
+
+| AC | Covered by |
+| --- | --- |
+| AC-01 | API-01, UI-08, E2E-01 |
+| AC-02 | UI-03 |
+| AC-03 | API-06, API-14, E2E-02 |
+| AC-04 | API-02, UI-05 |
+| AC-05 | API-03 |
+| AC-06 | API-04 |
+| AC-07 | UI-06 |
+| AC-08 | UI-07 |
+| AC-09 | API-15, E2E-01 |
+| AC-10 | API-16, UI-16 |
+| AC-11 | API-17, UI-09 |
+| AC-12 | API-18 |
+| AC-13 | API-23 |
+| AC-14 | API-21, UI-15, E2E-03 |
+| AC-15 | API-20, UI-15, E2E-03 |
+| AC-16 | API-07, UI-13, E2E-01 |
+| AC-17 | API-08 |
+| AC-18 | API-09, UI-12 |
+| AC-19 | API-12, UI-11 |
+| AC-20 | API-11, UI-10 |
+| AC-21 | UI-02 |
+| AC-22 | API-24, UI-01 |
+| AC-23 | UI-04, E2E-02 |
+| AC-24 | API-13, UI-14, E2E-01 |
+| AC-25 | STYLE-02, STYLE-03, STYLE-04 |
+| AC-26 | UI-05 |
+
+Every AC-01–AC-26 has at least one row; every planned test names a real
+file path under the required minimum Lab 2 structure (handout §12),
+extended with `dev-requesters.api.test.ts` and
+`DevRequesterSelection.test.tsx`/`AttachmentSection.test.tsx` since the
+handout's list is a stated minimum, not a ceiling.
+
+## 4. Responsive / Visual Checklist
+
+Mirrors `ui-spec.md` §12 — completed with screenshot evidence during
+implementation:
+
+- [ ] No clipped labels at any viewport (desktop ≥992px, tablet 768–991px,
+      mobile <768px)
+- [ ] No overlapping messages (validation, badges, toasts)
+- [ ] No unintended horizontal scrolling at any viewport
+- [ ] Consistent field styling (editable/read-only/invalid/disabled) across
+      Create Ticket and Ticket Detail
+- [ ] Badge colors/labels consistent for the same Priority/Status value
+      across My Tickets and Ticket Detail
+- [ ] Filters, pagination, and attachment controls remain usable at all
+      three viewports
+- [ ] Desktop table ↔ mobile card transformation on My Tickets preserves
+      all information
+
+## 5. Test Commands
+
+To be run once implementation exists (not yet — this is a pre-code spec
+deliverable):
+
+```bash
+# Server: unit + API/integration tests (Vitest + Supertest)
+pnpm --filter server test
+
+# Client: UI component + style tests (Vitest + Testing Library)
+pnpm --filter client test
+
+# E2E + visual/responsive screenshots (Playwright)
+# NOTE: Playwright is not yet part of this workspace — see Known Limitations.
+npx playwright test e2e/lab-02
+```
+
+## 6. Final Results
+
+Not yet run. Implementation has not started under this task, per the
+Spec-Driven Development scope of this session — this file records the
+*plan* the coding agent must satisfy, not evidence of a working system.
+Once each GitHub Issue is implemented, this section must be updated with
+actual pass/fail status and command output from the final `main` branch,
+replacing every `Planned` in §2 with `Pass`/`Fail`, per the handout's Test
+DD requirement (§9).
+
+## 7. Known Limitations or Deferred Tests
+
+- **Search has no dedicated index.** `search` uses a case-insensitive
+  `ILIKE` scan against `ticketNumber`/`summary`. Fine at Lab 2 seed-data
+  scale; add a trigram/full-text index if ticket volume grows in a later
+  lab.
+- **No server-side idempotency key for ticket creation.** Duplicate-submit
+  prevention (BR-22) is client-side (disabled/busy Submit button) only.
+  Acceptable for this lab's realistic usage pattern; add an idempotency key
+  if genuine duplicate-ticket incidents are ever observed.
+- **File-type validation is extension + declared Content-Type, not
+  magic-byte content sniffing.** Sufficient for the trust level of this lab
+  (a Development Requester, not a hostile actor); magic-byte sniffing is a
+  reasonable future hardening, not required by BR-25.
+- **5-active-attachment limit enforcement is check-then-insert**, not
+  wrapped in a serializable transaction. Acceptable at this lab's
+  concurrency level (a single Requester uploading from one browser tab); a
+  race would require the same Requester uploading two files to the same
+  ticket in the same instant.
+- **No automated accessibility (axe-core) scan is configured.** §7 of
+  `ui-spec.md` is checked via the manual/visual checklist in §4 above, not
+  an automated a11y test suite, for this lab.
+- **Playwright is not yet an installed dependency** in this workspace
+  (confirmed via `client/package.json` / `server/package.json` /
+  `pnpm-workspace.yaml` — no `e2e` package exists yet). Adding it, plus an
+  `e2e` workspace package or root devDependency, is implementation work for
+  the "E2E testing" GitHub Issue, not part of this specification task.

--- a/docs/lab-02/ui-spec.md
+++ b/docs/lab-02/ui-spec.md
@@ -1,0 +1,295 @@
+# Lab 2 UI Specification — Zen Green Theme
+
+This document is the visual and behavioral contract for every Lab 2 screen.
+Later labs reuse these tokens and component rules rather than inventing a
+new visual system — only the four required screens change per sprint.
+
+## 1. Color Tokens
+
+Reproduced from the handout (§7), plus the concrete hex values this
+specification commits to where the handout only gave a description
+(flagged with a note — these are cheap to swap, they're just consistent
+choices so every screen agrees).
+
+| Token | Hex | Required use |
+| --- | --- | --- |
+| `--zg-primary` | `#006B3C` | App header, primary actions, strong emphasis |
+| `--zg-secondary` | `#0B7A46` | Active tabs, focus accents, links, hover states |
+| `--zg-pale` | `#EAF6EF` | Selected state, success surfaces, subtle section emphasis |
+| `--zg-bg` | `#F5F7F6` | Page background |
+| `--zg-surface` | `#FFFFFF` | Cards/panels, with a subtle 1px border and restrained shadow |
+| `--zg-text` | `#1C2B24` *(chosen: dark charcoal-green, not pure black)* | Body text |
+| `--zg-field-editable-bg` | `#FFFFFF` | Editable field background |
+| `--zg-field-editable-border` | `#C9D6D0` *(chosen)* | Editable field border |
+| `--zg-field-readonly-bg` | `#EDF3EF` *(chosen: soft gray-green)* | Read-only / system-generated field background |
+| `--zg-field-readonly-border` | `#D7E3DD` *(chosen)* | Read-only field border |
+| `--zg-error-text` / `--zg-error-border` | `#B3261E` | Error text/border; message directly below the field |
+| `--zg-warning-bg` / `--zg-warning-text` | `#FCEED1` / `#8A5A00` *(chosen)* | Amber callout/badge only — never decorative |
+| `--zg-success-bg` / `--zg-success-text` | `--zg-pale` (`#EAF6EF`) / `--zg-secondary` (`#0B7A46`) | Success confirmation, always paired with an icon/text, never color alone |
+
+## 2. Typography and Spacing
+
+- Base font: system UI stack (matches the existing Bootstrap baseline
+  already in `client/package.json`; Zen Green layers tokens on top of it,
+  it does not replace it).
+- Screen title: 24px / semi-bold / `--zg-text`.
+- Section heading (e.g. "Attachments", "Description"): 16px / semi-bold /
+  `--zg-text`.
+- Field label: 14px / medium weight / `--zg-text`, positioned directly
+  above its control with 4px gap.
+- Body / table text: 14px / regular / `--zg-text`.
+- Helper / validation text: 13px.
+- Spacing scale: 4 / 8 / 12 / 16 / 24 / 32px. Cards use 16–24px internal
+  padding; sections within a card are separated by 24px.
+
+## 3. Field States
+
+| State | Appearance |
+| --- | --- |
+| Editable | `--zg-field-editable-bg` fill, `--zg-field-editable-border` 1px border, `--zg-text` value color. |
+| Read-only / system-generated | `--zg-field-readonly-bg` fill, `--zg-field-readonly-border` border, same text color but not focusable/typeable (e.g. Ticket Number, Ticket Date, Requester). A small label or icon may reinforce "read-only" but the background contrast is the primary signal. |
+| Focused | 2px outline in `--zg-secondary`, always visible — never suppressed, including for keyboard-only navigation. |
+| Invalid | `--zg-error-border` border, `--zg-error-text` message rendered immediately below the field (never only in a page-level summary — AC-26). The red asterisk on required fields is a separate, permanent marker and does not replace this message. |
+| Disabled | Reduced-opacity fill and text, border in a muted neutral tone, `cursor: not-allowed`, and `aria-disabled="true"` — visually distinct enough that it does not read as an active editable field. |
+
+**Required-field marker**: a red asterisk (`*`) directly after the label
+text, on every required field, at all times — not only after a failed
+validation attempt.
+
+## 4. Button Hierarchy
+
+| Role | Style | Example |
+| --- | --- | --- |
+| Primary | Solid `--zg-primary` fill, white text | Submit, Continue, Create Ticket |
+| Secondary | White fill, `--zg-primary` border and text | Cancel, Back to My Tickets |
+| Tertiary / link-style | No fill/border, `--zg-secondary` text, underline on hover | Clear Filters, Change Requester |
+| Destructive | White fill, `--zg-error-text` border and text (confirmed via a dialog before the action fires) | Remove Attachment |
+| Disabled | Reduced opacity, `cursor: not-allowed`, no hover/focus change until re-enabled | Submit while invalid, Upload at the 5-attachment cap |
+| Busy | Primary style + inline spinner + "Submitting…" text, `disabled` attribute set so repeat clicks are impossible (BR-22/AC-07) | Submit while the create request is in flight |
+
+Every button shows visible text. Icons may accompany text but never replace
+it; any icon-only control (e.g. a table-row overflow menu) has an
+accessible label and a tooltip.
+
+## 5. Validation, Loading, and Result States
+
+Applies to every screen that talks to the API:
+
+| State | Behavior |
+| --- | --- |
+| Initial | Form/list rendered with no messages; read-only fields pre-filled where applicable (e.g. Requester on Create Ticket). |
+| Loading | Skeleton or centered spinner with descriptive text (e.g. "Loading your tickets…"); interactive controls that depend on the data are disabled, not hidden (avoids layout shift). |
+| Validating | Client-side checks run on blur and on submit attempt; failing fields get the Invalid state from §3 immediately, without waiting for a server round-trip. |
+| Submitting | Primary action shows the Busy state (§4); the rest of the form remains visible but is not editable. |
+| Success | A visible confirmation (icon + text, never color alone) — for Create Ticket, the generated Ticket Number and a clear next action ("View Ticket" / "Create Another"). |
+| Failure (server/network) | A page-level error banner (not a silent console failure) using `--zg-error-text`, plus the form's entered values preserved exactly as typed (BR-23/AC-08). No dead-end: the Requester can retry without re-entering data. |
+| Empty | Distinct copy + a primary action pointing at what to do next (e.g. Create Ticket). Used only when the Requester truly has zero of the resource, ignoring filters (BR-30). |
+| No results | Distinct from Empty — used when filters/search produced zero matches despite the Requester owning data; always paired with a Clear Filters action. |
+
+## 6. Attachment Presentation
+
+| State | Appearance |
+| --- | --- |
+| Active | File name, size, uploaded date, a Download action, and a Remove action (destructive style, §4). |
+| Uploading | Row shown immediately with the file name, a progress/busy indicator, no Download/Remove actions until it resolves. |
+| Invalid (rejected client- or server-side) | Row shown with `--zg-error-text` message explaining why (type/size/limit), a Retry or Dismiss action, never silently dropped. |
+| Removed | File name and size still shown (muted/secondary text), a "Removed" badge, removal date, no Download action present at all (not just disabled — BR-28/AC-15). |
+| Upload control disabled | Once 5 active Attachments exist, the upload control shows a disabled state with adjacent copy explaining the 5-attachment limit, not just a silently-inert button. |
+
+## 7. Accessibility
+
+- Every form control has a programmatically associated `<label>` (not
+  placeholder-only labeling).
+- Icon-only controls carry `aria-label` and a visible tooltip on hover/focus.
+- Focus indicators (§3) are never removed via CSS.
+- Status/priority meaning is never conveyed by color alone — badges (§9)
+  always pair color with text.
+- All interactive controls (dropdowns, buttons, pagination, filters,
+  attachment actions) are reachable and operable via keyboard alone (Tab /
+  Shift+Tab / Enter / Space), matching the handout's requirement for the
+  Development Requester Selection screen and extended to every screen built
+  on the same components.
+- Error and success messages use `role="alert"` / `aria-live="polite"` as
+  appropriate so screen readers announce them without a page reload.
+
+## 8. Responsive Rules
+
+| Viewport | Required behavior |
+| --- | --- |
+| Desktop ≥ 992px | Multi-column layout as specified per screen below; content centered with a sensible max width (this spec uses 1140px). |
+| Tablet 768–991px | Two-column layout where practical; Summary and Description keep full usable width. |
+| Mobile < 768px | Fields stack vertically; buttons remain touch-friendly (min 44px tap target); no horizontal page scrolling under any circumstance. |
+| All sizes | No clipped labels, overlapping messages, hidden buttons, or unreadable attachment names — verified visually per the checklist in §12. |
+
+## 9. Badges
+
+| Requested Priority / IT Priority | Color |
+| --- | --- |
+| Low | `--zg-pale` background, `--zg-secondary` text |
+| Medium | `--zg-warning-bg` background, `--zg-warning-text` text |
+| High | Light red background (`#FBE7E5`), `--zg-error-text` text |
+
+| Current Status | Color |
+| --- | --- |
+| New | Light blue-gray background (`#E7EEF5`), dark blue-gray text (`#33475B`) |
+| Open | Light blue background (`#DCEBFB`), blue text (`#1B5FA8`) |
+| In Progress | `--zg-warning-bg` background, `--zg-warning-text` text |
+| Pending | `--zg-warning-bg` background, `--zg-warning-text` text, with a distinct icon from In Progress since color alone repeats |
+| Resolved | `--zg-pale` background, `--zg-secondary` text |
+| Closed | Light neutral gray background (`#EAEAEA`), gray text (`#5A5A5A`) |
+| Cancelled | Light neutral gray background (`#EAEAEA`), gray text (`#5A5A5A`), with a distinct icon from Closed |
+
+Every badge shows its label text; color is a reinforcement, never the only
+signal (§7).
+
+## 10. Application Shell and Navigation
+
+- Header: `--zg-primary` background, white "TokTickIT" wordmark/icon on the
+  left, "My Tickets" and "Create Ticket" nav items, current Requester name
+  + a "Profile"-style menu containing "Change Requester" on the right.
+- Active page indicated by an underline/weight change in `--zg-secondary`
+  on the corresponding nav item (never color alone — the active item's text
+  weight also changes).
+- Mobile (< 768px): nav collapses behind a menu control; the current
+  Requester name and Change Requester action remain reachable within one
+  tap.
+- Displayed everywhere except the Development Requester Selection screen
+  itself (which has no meaningful "current Requester" yet).
+
+## 11. Screen-by-Screen Layout
+
+### 11.1 Development Requester Selection
+
+- Centered card on the page background, no application shell chrome above
+  it except the TokTickIT wordmark.
+- Icon + "Select Development Requester" heading + one sentence of
+  explanatory copy: *"Select a Development Requester to test
+  requester-specific ticket behavior. This is not a login screen.
+  Authentication and role-based access will be introduced in Lab 3."*
+- Required `Development Requester` dropdown (label + red asterisk),
+  populated only with active Requesters (BR-09), sorted by name.
+- An info callout: *"Only active development requesters are shown."*
+- A secondary callout explaining the Lab 3 transition (shield icon +
+  "Authentication coming in Lab 3" text), matching the handout's
+  illustrative screenshot.
+- Cancel (secondary) / Continue (primary, disabled until a Requester is
+  chosen) actions.
+- **Loading**: dropdown area shows a loading skeleton while active
+  Requesters are fetched; Continue stays disabled.
+- **Empty** (no active Requesters returned): dropdown replaced by a message
+  stating no active Development Requesters are configured, with no path
+  forward other than contacting course staff — Continue stays disabled.
+- **API failure**: safe error banner, retry action, no crash (AC-21).
+- After Continue: the app shell renders with the chosen Requester's name
+  shown and a Change Requester action available (§10); all
+  Requester-scoped data (My Tickets, etc.) loads fresh for the new
+  selection.
+
+### 11.2 Create Ticket
+
+Top to bottom, single card, full width up to the max content width:
+
+1. **System-generated row** (read-only style, §3): Ticket Number
+   ("Generated after submission" placeholder text pre-success — never
+   blank-looking), Ticket Date (shows "Generated after submission"
+   pre-success, the actual timestamp after), Requester (pre-filled from the
+   current selection, read-only).
+2. **Classification group**: Category, Related System (both required
+   dropdowns, side by side on desktop/tablet, stacked on mobile),
+   Requested Priority (required, no default — §3 of `specification.md`
+   §11-7).
+3. **Summary**: full-width single-line input, required, 5–120 chars, live
+   character count shown once near the limit.
+4. **Description**: full-width multiline textarea, required, 10–2000
+   chars, resizable vertically only, live character count shown once near
+   the limit.
+5. **Attachments**: file picker below Description, showing selected files
+   in the states from §6, capped at 5 total (existing active + newly
+   selected in this session).
+6. **Actions row**: Cancel (secondary) on the left, Submit (primary) on
+   the right; Submit shows the Busy state (§4) while in flight.
+7. **Success state** replaces the form actions with the generated Ticket
+   Number, a success confirmation, and "View Ticket" / "Create Another"
+   actions.
+
+Desktop (≥992px): classification group is a 2–3 column row. Tablet: 2
+columns. Mobile: every field full width, stacked in the same top-to-bottom
+order.
+
+### 11.3 My Tickets
+
+- Page header: "My Tickets" title + one-line subtitle, "Clear Filters"
+  (tertiary) and "Create Ticket" (primary) actions top-right.
+- Filter row: search input (placeholder "Search by ticket number or
+  summary…"), Category / Requested Priority / Current Status dropdowns
+  (each defaulting to "All …"). Row wraps to multiple lines on tablet,
+  stacks fully on mobile.
+- **Desktop/tablet**: sortable table with columns Ticket No. (linked to
+  Ticket Detail), Created Date, Summary, Category, Requested Priority
+  (badge), Current Status (badge), Last Updated. Sortable column headers
+  show a direction indicator.
+- **Mobile (< 768px)**: table becomes a stacked card list — one card per
+  Ticket, Ticket No. and Summary prominent, badges for Priority/Status,
+  Created/Updated dates secondary, whole card tappable to open Ticket
+  Detail. No horizontal scroll is introduced as a substitute for this
+  transformation.
+- Pagination control below the list: Previous/Next, page numbers, "Showing
+  X to Y of Z tickets" text — matches the handout's illustrative
+  screenshot.
+- **Loading**: skeleton rows/cards, filters remain interactive.
+- **Empty** (BR-30, §5 of this doc): illustration/icon + "You haven't
+  created any tickets yet" + Create Ticket primary action; filters are
+  hidden or disabled since there's nothing to filter.
+- **No results** (BR-30): "No tickets match your filters" + Clear Filters
+  action; filters remain visible/interactive.
+- **Failure**: safe error banner with retry; existing filter/search values
+  are preserved so the Requester doesn't lose their query.
+
+### 11.4 Requester Ticket Detail
+
+- Breadcrumb: "My Tickets > Ticket Detail", with a "Back to My Tickets"
+  action top-right.
+- **Ticket information card** (read-only, §3, grouped separately from
+  Attachments): Ticket No., Ticket Date, Category, Related System,
+  Requester, Requested Priority (badge), Current Status (badge), Summary,
+  Description. No Public Comments, Internal Notes, Actions Taken, IT
+  Priority, or Ticket Owner fields are rendered — those belong to a later
+  lab and must not appear even as disabled placeholders (matches handout
+  §8.5: "must not implement Public Comments, Internal Notes, Actions Taken
+  or later status-workflow features").
+- **Attachments section**, visually distinct from the Ticket information
+  card (separate heading/card boundary): list of Attachments in the states
+  from §6, an upload control (disabled at the 5-active cap), and per-file
+  Download/Remove actions where applicable.
+- Removing an Attachment opens a confirmation dialog with an optional
+  reason field (§11-2 of `specification.md`) before the soft-remove call
+  fires.
+- Desktop/tablet: information card fields laid out in a responsive grid
+  (2–4 columns depending on width, matching the handout's illustrative
+  screenshot grouping). Mobile: single column, same field order.
+
+## 12. Visual Inspection Checklist
+
+To be completed with dated screenshot evidence during implementation, not
+during this specification task:
+
+- [ ] No clipped labels at any viewport
+- [ ] No overlapping messages (validation, badges, toasts)
+- [ ] No unintended horizontal scrolling at any viewport
+- [ ] Consistent field styling (editable vs. read-only vs. invalid vs.
+      disabled) across Create Ticket and Ticket Detail
+- [ ] Badge colors/labels consistent between My Tickets and Ticket Detail
+      for the same Priority/Status values
+- [ ] Filters, pagination, attachment controls remain usable at all three
+      viewports
+- [ ] Desktop table ↔ mobile card transformation on My Tickets shows the
+      same information, not a subset
+
+## 13. Screenshot Paths
+
+Per the required repository structure, implementation-phase Playwright
+screenshots are saved to:
+
+- `artifacts/lab-02/screenshots/create-ticket/{desktop,tablet,mobile}.png`
+- `artifacts/lab-02/screenshots/my-tickets/{desktop,tablet,mobile}.png`
+- `artifacts/lab-02/screenshots/ticket-detail/{desktop,tablet,mobile}.png`


### PR DESCRIPTION
Closes #15 

## Summary

Adds the four required Spec-Driven Development documents for Lab 2 (TokTickIT Requester Ticketing MVP) under `docs/lab-02/`:

- `specification.md`: sprint goal, scope, 14 functional requirements, 31 business rules, target Prisma schema, 26 acceptance criteria, and definition of done. Section 11 lists every interpretive call made where the handout left the decision to the student, tagged by how costly each would be to change later.
- `api-spec.md`: 9 endpoints with request/response shapes and every status code they can return.
- `ui-spec.md`: Zen Green tokens, component states, responsive rules, and a screen-by-screen layout for all four Requester screens.
- `tests.md`: 52 planned tests across unit, API, UI, style, and E2E levels, with an acceptance-criterion traceability matrix and known limitations.

No application code, schema migration, or config changed. This is the contract the coding agent implements against in the next Issue.

A follow-up commit hardens one decision after review: the current requester must be resolved through a single backend helper and a single frontend API wrapper, not read ad hoc at each call site. Ownership checks (BR-14/BR-15) already take a requester id as a plain argument, so Lab 3's real auth only has to replace those two seams instead of touching every endpoint.

## Test plan

- [ ] No automated tests yet, this PR is documentation only
- [ ] Reviewer reads `specification.md` §11 and confirms the flagged assumptions
- [ ] Reviewer confirms every AC-01–AC-26 in `specification.md` has a matching row in `tests.md`'s traceability matrix
- [ ] Reviewer confirms `api-spec.md` status codes and `ui-spec.md` tokens agree with `specification.md`
