### PR TITLE
Development requester context and selection screen

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,13 @@ Full-stack monorepo:
    pnpm prisma:migrate
    ```
 
+5. Seed reference data and the Lab 2 Development Requesters (safe to re-run):
+
+   ```bash
+   cd server
+   pnpm prisma:seed
+   ```
+
 ## Running the apps
 
 In separate terminals:
@@ -50,6 +57,11 @@ In separate terminals:
 cd server && pnpm dev   # http://localhost:3001
 cd client && pnpm dev   # http://localhost:5173
 ```
+
+The app opens on the Development Requester Selection screen
+(`/select-requester`). Pick a seeded Requester to reach the requester-scoped
+screens — this is a Lab 2 testing mechanism, not authentication. The Lab 1
+system check now lives at `/system-check`.
 
 ## Testing
 

--- a/client/package.json
+++ b/client/package.json
@@ -13,9 +13,13 @@
   "dependencies": {
     "bootstrap": "^5.3.8",
     "react": "^19.2.8",
-    "react-dom": "^19.2.8"
+    "react-dom": "^19.2.8",
+    "react-router-dom": "^7.18.3"
   },
   "devDependencies": {
+    "@testing-library/dom": "^10.4.1",
+    "@testing-library/react": "^16.3.3",
+    "@testing-library/user-event": "^14.6.7",
     "@types/node": "^24.13.3",
     "@types/react": "^19.2.17",
     "@types/react-dom": "^19.2.3",

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -1,50 +1,62 @@
-import { useState } from 'react'
-import CategoryList from './CategoryList'
+import { BrowserRouter, Navigate, Outlet, Route, Routes } from 'react-router-dom'
+import AppShell from './AppShell'
+import DevRequesterSelection from './DevRequesterSelection'
+import { RequesterProvider, useRequester } from './RequesterContext'
+import SystemCheck from './SystemCheck'
 
-type CheckState = 'idle' | 'checking' | 'online' | 'offline'
+// ponytail: placeholder until the Create Ticket / My Tickets / Ticket Detail
+// issues land. The routes exist now only so the BR-12 guard has something to
+// guard; replace the element, not the routing.
+function ComingSoon({ title }: { title: string }) {
+  return (
+    <div className="zg-card">
+      <h1 className="zg-title">{title}</h1>
+      <p className="zg-helper">This screen arrives in a later Lab 2 issue.</p>
+    </div>
+  )
+}
 
-function App() {
-  const [state, setState] = useState<CheckState>('idle')
-
-  const checkSystem = () => {
-    setState('checking')
-    fetch('/api/health')
-      .then((res) => {
-        if (!res.ok) throw new Error(`Backend responded with ${res.status}`)
-        return res.json()
-      })
-      .then(() => setState('online'))
-      .catch(() => setState('offline'))
-  }
+/** BR-12: no selected Requester means every Requester-scoped screen bounces to
+ *  the selection screen, whether reached by nav or by a pasted URL. */
+function RequireRequester() {
+  const { requester } = useRequester()
+  if (!requester) return <Navigate to="/select-requester" replace />
 
   return (
-    <div className="container py-5 text-center">
-      <h1>TokTickIT IT Service Desk</h1>
+    <AppShell>
+      {/* FR-13: keying on the requester id remounts every Requester-scoped
+          screen on a switch, so their data reloads instead of going stale. */}
+      <div key={requester.id} data-testid="requester-scope" data-requester-id={requester.id}>
+        <Outlet />
+      </div>
+    </AppShell>
+  )
+}
 
-      <button
-        type="button"
-        className="btn btn-primary my-3"
-        onClick={checkSystem}
-        disabled={state === 'checking'}
-      >
-        Check System
-      </button>
+export function AppRoutes() {
+  return (
+    <Routes>
+      <Route path="/select-requester" element={<DevRequesterSelection />} />
+      <Route path="/system-check" element={<SystemCheck />} />
 
-      {state === 'online' && (
-        <>
-          <p className="lead text-success">System Status: Online</p>
-          <h2 className="h5">Supported Request Categories</h2>
-          <CategoryList />
-        </>
-      )}
+      <Route element={<RequireRequester />}>
+        <Route path="/tickets" element={<ComingSoon title="My Tickets" />} />
+        <Route path="/tickets/new" element={<ComingSoon title="Create Ticket" />} />
+        <Route path="/tickets/:id" element={<ComingSoon title="Ticket Detail" />} />
+      </Route>
 
-      {state === 'offline' && (
-        <>
-          <p className="lead text-danger mb-0">System Status: Offline</p>
-          <p className="text-danger">Unable to connect to TokTickIT API</p>
-        </>
-      )}
-    </div>
+      <Route path="*" element={<Navigate to="/tickets" replace />} />
+    </Routes>
+  )
+}
+
+function App() {
+  return (
+    <BrowserRouter>
+      <RequesterProvider>
+        <AppRoutes />
+      </RequesterProvider>
+    </BrowserRouter>
   )
 }
 

--- a/client/src/AppShell.tsx
+++ b/client/src/AppShell.tsx
@@ -1,0 +1,52 @@
+import type { ReactNode } from 'react'
+import { NavLink, useNavigate } from 'react-router-dom'
+import { useRequester } from './RequesterContext'
+
+const navClass = ({ isActive }: { isActive: boolean }) =>
+  isActive ? 'zg-navlink is-active' : 'zg-navlink'
+
+function AppShell({ children }: { children: ReactNode }) {
+  const { requester, clearRequester } = useRequester()
+  const navigate = useNavigate()
+
+  // BR-11: available at all times; clears the previous context and returns to
+  // the selection screen.
+  const changeRequester = () => {
+    clearRequester()
+    navigate('/select-requester')
+  }
+
+  return (
+    <>
+      <header className="zg-header">
+        <div className="zg-header-inner">
+          <NavLink to="/tickets" className="zg-wordmark">
+            TokTickIT
+          </NavLink>
+
+          <nav className="zg-nav" aria-label="Main">
+            <NavLink to="/tickets" className={navClass} end>
+              My Tickets
+            </NavLink>
+            <NavLink to="/tickets/new" className={navClass}>
+              Create Ticket
+            </NavLink>
+          </nav>
+
+          <div className="zg-header-requester">
+            <span data-testid="current-requester">
+              Testing as <strong>{requester?.name}</strong>
+            </span>
+            <button type="button" className="zg-btn zg-btn-tertiary" onClick={changeRequester}>
+              Change Requester
+            </button>
+          </div>
+        </div>
+      </header>
+
+      <main className="zg-page">{children}</main>
+    </>
+  )
+}
+
+export default AppShell

--- a/client/src/DevRequesterSelection.tsx
+++ b/client/src/DevRequesterSelection.tsx
@@ -1,0 +1,132 @@
+import { useCallback, useEffect, useState } from 'react'
+import { useNavigate } from 'react-router-dom'
+import { useRequester, type Requester } from './RequesterContext'
+
+type LoadState = 'loading' | 'ready' | 'error'
+
+function DevRequesterSelection() {
+  const [state, setState] = useState<LoadState>('loading')
+  const [requesters, setRequesters] = useState<Requester[]>([])
+  const [selectedId, setSelectedId] = useState('')
+  const { selectRequester } = useRequester()
+  const navigate = useNavigate()
+
+  const load = useCallback(() => {
+    setState('loading')
+    setSelectedId('')
+    fetch('/api/dev-requesters')
+      .then((res) => {
+        if (!res.ok) throw new Error(`Backend responded with ${res.status}`)
+        return res.json() as Promise<Requester[]>
+      })
+      .then((data) => {
+        setRequesters(data)
+        setState('ready')
+      })
+      .catch(() => setState('error'))
+  }, [])
+
+  useEffect(load, [load])
+
+  const chosen = requesters.find((r) => String(r.id) === selectedId)
+
+  const handleContinue = () => {
+    if (!chosen) return
+    selectRequester(chosen)
+    navigate('/tickets')
+  }
+
+  return (
+    <div className="zg-page">
+      <h1 className="zg-wordmark" style={{ color: 'var(--zg-primary)' }}>
+        TokTickIT
+      </h1>
+
+      <div className="zg-card zg-select-screen" style={{ marginTop: 'var(--zg-space-5)' }}>
+        <h2 className="zg-title">
+          <span aria-hidden="true">👤 </span>Select Development Requester
+        </h2>
+
+        <p className="zg-helper" style={{ marginTop: 'var(--zg-space-2)' }}>
+          Select a Development Requester to test requester-specific ticket behavior. This is not a
+          login screen. Authentication and role-based access will be introduced in Lab 3.
+        </p>
+
+        {state === 'loading' && (
+          <p className="zg-skeleton" aria-live="polite" style={{ marginTop: 'var(--zg-space-5)' }}>
+            Loading development requesters…
+          </p>
+        )}
+
+        {state === 'error' && (
+          <div style={{ marginTop: 'var(--zg-space-5)' }}>
+            <p className="zg-error" role="alert">
+              Unable to load development requesters. Please try again.
+            </p>
+            <button type="button" className="zg-btn zg-btn-secondary" onClick={load}>
+              Retry
+            </button>
+          </div>
+        )}
+
+        {state === 'ready' && requesters.length === 0 && (
+          <p className="zg-callout" style={{ marginTop: 'var(--zg-space-5)' }}>
+            No active development requesters are configured. Please contact course staff — there is
+            nothing to select yet.
+          </p>
+        )}
+
+        {state === 'ready' && requesters.length > 0 && (
+          <div style={{ marginTop: 'var(--zg-space-5)' }}>
+            <label className="zg-label" htmlFor="dev-requester">
+              Development Requester <span className="zg-required">*</span>
+            </label>
+            <select
+              id="dev-requester"
+              className="zg-field"
+              required
+              value={selectedId}
+              onChange={(e) => setSelectedId(e.target.value)}
+            >
+              <option value="">Choose a development requester…</option>
+              {requesters.map((requester) => (
+                <option key={requester.id} value={requester.id}>
+                  {requester.name} ({requester.email})
+                </option>
+              ))}
+            </select>
+          </div>
+        )}
+
+        <p className="zg-callout" style={{ marginTop: 'var(--zg-space-4)' }}>
+          <span aria-hidden="true">ℹ️ </span>Only active development requesters are shown.
+        </p>
+
+        <p className="zg-callout" style={{ marginTop: 'var(--zg-space-3)' }}>
+          <span aria-hidden="true">🛡️ </span>Authentication coming in Lab 3 — this selection is for
+          testing only and grants no access rights.
+        </p>
+
+        <div className="zg-actions" style={{ marginTop: 'var(--zg-space-5)' }}>
+          <button
+            type="button"
+            className="zg-btn zg-btn-secondary"
+            onClick={() => setSelectedId('')}
+          >
+            Cancel
+          </button>
+          <button
+            type="button"
+            className="zg-btn zg-btn-primary"
+            disabled={!chosen}
+            onClick={handleContinue}
+          >
+            Continue
+          </button>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+export default DevRequesterSelection

--- a/client/src/RequesterContext.tsx
+++ b/client/src/RequesterContext.tsx
@@ -1,0 +1,59 @@
+import { createContext, useCallback, useContext, useMemo, useState, type ReactNode } from 'react'
+
+/** Lab 2 stores the selected Requester client-side only (BR-10). It is not a
+ *  session and grants no trust — every future API call still sends the id. */
+export const REQUESTER_STORAGE_KEY = 'toktickit.dev-requester'
+
+export type Requester = {
+  id: number
+  name: string
+  email: string
+}
+
+type RequesterContextValue = {
+  requester: Requester | null
+  selectRequester: (requester: Requester) => void
+  clearRequester: () => void
+}
+
+const RequesterContext = createContext<RequesterContextValue | null>(null)
+
+function readStoredRequester(): Requester | null {
+  try {
+    const raw = localStorage.getItem(REQUESTER_STORAGE_KEY)
+    if (!raw) return null
+    const parsed = JSON.parse(raw) as Partial<Requester>
+    if (typeof parsed?.id !== 'number' || typeof parsed?.name !== 'string') return null
+    return { id: parsed.id, name: parsed.name, email: String(parsed.email ?? '') }
+  } catch {
+    // Unreadable or corrupt storage counts as "nothing selected" (BR-12).
+    return null
+  }
+}
+
+export function RequesterProvider({ children }: { children: ReactNode }) {
+  const [requester, setRequester] = useState<Requester | null>(readStoredRequester)
+
+  const selectRequester = useCallback((next: Requester) => {
+    localStorage.setItem(REQUESTER_STORAGE_KEY, JSON.stringify(next))
+    setRequester(next)
+  }, [])
+
+  const clearRequester = useCallback(() => {
+    localStorage.removeItem(REQUESTER_STORAGE_KEY)
+    setRequester(null)
+  }, [])
+
+  const value = useMemo(
+    () => ({ requester, selectRequester, clearRequester }),
+    [requester, selectRequester, clearRequester],
+  )
+
+  return <RequesterContext.Provider value={value}>{children}</RequesterContext.Provider>
+}
+
+export function useRequester() {
+  const value = useContext(RequesterContext)
+  if (!value) throw new Error('useRequester must be used inside a RequesterProvider')
+  return value
+}

--- a/client/src/SystemCheck.tsx
+++ b/client/src/SystemCheck.tsx
@@ -1,0 +1,51 @@
+import { useState } from 'react'
+import CategoryList from './CategoryList'
+
+type CheckState = 'idle' | 'checking' | 'online' | 'offline'
+
+function SystemCheck() {
+  const [state, setState] = useState<CheckState>('idle')
+
+  const checkSystem = () => {
+    setState('checking')
+    fetch('/api/health')
+      .then((res) => {
+        if (!res.ok) throw new Error(`Backend responded with ${res.status}`)
+        return res.json()
+      })
+      .then(() => setState('online'))
+      .catch(() => setState('offline'))
+  }
+
+  return (
+    <div className="container py-5 text-center">
+      <h1>TokTickIT IT Service Desk</h1>
+
+      <button
+        type="button"
+        className="btn btn-primary my-3"
+        onClick={checkSystem}
+        disabled={state === 'checking'}
+      >
+        Check System
+      </button>
+
+      {state === 'online' && (
+        <>
+          <p className="lead text-success">System Status: Online</p>
+          <h2 className="h5">Supported Request Categories</h2>
+          <CategoryList />
+        </>
+      )}
+
+      {state === 'offline' && (
+        <>
+          <p className="lead text-danger mb-0">System Status: Offline</p>
+          <p className="text-danger">Unable to connect to TokTickIT API</p>
+        </>
+      )}
+    </div>
+  )
+}
+
+export default SystemCheck

--- a/client/src/main.tsx
+++ b/client/src/main.tsx
@@ -1,6 +1,7 @@
 import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
 import 'bootstrap/dist/css/bootstrap.min.css'
+import './zen-green.css'
 import App from './App.tsx'
 
 createRoot(document.getElementById('root')!).render(

--- a/client/src/zen-green.css
+++ b/client/src/zen-green.css
@@ -1,0 +1,226 @@
+/* Zen Green design tokens — ui-spec.md §1. Layered over Bootstrap, not
+   replacing it. Only the rules the shipped screens need live here; later
+   screens add their own. */
+:root {
+  --zg-primary: #006b3c;
+  --zg-secondary: #0b7a46;
+  --zg-pale: #eaf6ef;
+  --zg-bg: #f5f7f6;
+  --zg-surface: #ffffff;
+  --zg-text: #1c2b24;
+  --zg-field-editable-bg: #ffffff;
+  --zg-field-editable-border: #c9d6d0;
+  --zg-field-readonly-bg: #edf3ef;
+  --zg-field-readonly-border: #d7e3dd;
+  --zg-error-text: #b3261e;
+  --zg-error-border: #b3261e;
+  --zg-warning-bg: #fceed1;
+  --zg-warning-text: #8a5a00;
+  --zg-success-bg: var(--zg-pale);
+  --zg-success-text: var(--zg-secondary);
+
+  --zg-space-1: 4px;
+  --zg-space-2: 8px;
+  --zg-space-3: 12px;
+  --zg-space-4: 16px;
+  --zg-space-5: 24px;
+  --zg-space-6: 32px;
+  --zg-max-width: 1140px;
+}
+
+body {
+  background: var(--zg-bg);
+  color: var(--zg-text);
+  font-size: 14px;
+}
+
+.zg-page {
+  max-width: var(--zg-max-width);
+  margin: 0 auto;
+  padding: var(--zg-space-5) var(--zg-space-4);
+}
+
+.zg-card {
+  background: var(--zg-surface);
+  border: 1px solid var(--zg-field-readonly-border);
+  border-radius: 8px;
+  box-shadow: 0 1px 2px rgb(28 43 36 / 8%);
+  padding: var(--zg-space-5);
+}
+
+.zg-title {
+  font-size: 24px;
+  font-weight: 600;
+  color: var(--zg-text);
+}
+
+.zg-label {
+  display: block;
+  font-size: 14px;
+  font-weight: 500;
+  margin-bottom: var(--zg-space-1);
+}
+
+.zg-required {
+  color: var(--zg-error-text);
+}
+
+.zg-helper {
+  font-size: 13px;
+}
+
+.zg-field {
+  width: 100%;
+  background: var(--zg-field-editable-bg);
+  border: 1px solid var(--zg-field-editable-border);
+  border-radius: 6px;
+  color: var(--zg-text);
+  padding: var(--zg-space-2) var(--zg-space-3);
+}
+
+/* Focus is never suppressed, including for keyboard-only users — ui-spec §3/§7. */
+.zg-field:focus-visible,
+.zg-btn:focus-visible,
+.zg-navlink:focus-visible {
+  outline: 2px solid var(--zg-secondary);
+  outline-offset: 2px;
+}
+
+.zg-callout {
+  background: var(--zg-pale);
+  border: 1px solid var(--zg-field-readonly-border);
+  border-radius: 6px;
+  color: var(--zg-text);
+  font-size: 13px;
+  padding: var(--zg-space-3);
+}
+
+.zg-error {
+  background: #fbe7e5;
+  border: 1px solid var(--zg-error-border);
+  border-radius: 6px;
+  color: var(--zg-error-text);
+  padding: var(--zg-space-3);
+}
+
+.zg-skeleton {
+  background: var(--zg-field-readonly-bg);
+  border-radius: 6px;
+  color: var(--zg-text);
+  padding: var(--zg-space-3);
+}
+
+/* Buttons — ui-spec §4. Every button keeps visible text. */
+.zg-btn {
+  border-radius: 6px;
+  border: 1px solid transparent;
+  cursor: pointer;
+  font-size: 14px;
+  font-weight: 500;
+  min-height: 44px; /* touch target at mobile widths — ui-spec §8 */
+  padding: var(--zg-space-2) var(--zg-space-5);
+}
+
+.zg-btn-primary {
+  background: var(--zg-primary);
+  border-color: var(--zg-primary);
+  color: #fff;
+}
+
+.zg-btn-secondary {
+  background: #fff;
+  border-color: var(--zg-primary);
+  color: var(--zg-primary);
+}
+
+.zg-btn-tertiary {
+  background: none;
+  border: none;
+  color: var(--zg-secondary);
+  min-height: auto;
+  padding: var(--zg-space-1) var(--zg-space-2);
+}
+
+.zg-btn-tertiary:hover {
+  text-decoration: underline;
+}
+
+.zg-btn:disabled,
+.zg-btn[aria-disabled='true'] {
+  cursor: not-allowed;
+  opacity: 0.55;
+}
+
+/* Application shell — ui-spec §10. */
+.zg-header {
+  background: var(--zg-primary);
+  color: #fff;
+}
+
+.zg-header-inner {
+  align-items: center;
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--zg-space-3);
+  margin: 0 auto;
+  max-width: var(--zg-max-width);
+  padding: var(--zg-space-3) var(--zg-space-4);
+}
+
+.zg-wordmark {
+  color: #fff;
+  font-size: 18px;
+  font-weight: 600;
+  text-decoration: none;
+}
+
+.zg-nav {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--zg-space-4);
+  flex: 1 1 auto;
+}
+
+.zg-navlink {
+  color: #fff;
+  padding: var(--zg-space-1) 0;
+  text-decoration: none;
+}
+
+/* Active page: weight change plus an underline, never colour alone (§10). */
+.zg-navlink.is-active {
+  border-bottom: 2px solid var(--zg-secondary);
+  font-weight: 700;
+}
+
+.zg-header-requester {
+  align-items: center;
+  color: #fff;
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--zg-space-2);
+}
+
+.zg-header .zg-btn-tertiary {
+  color: #fff;
+  text-decoration: underline;
+}
+
+.zg-select-screen {
+  margin: 0 auto;
+  max-width: 560px;
+}
+
+.zg-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--zg-space-3);
+  justify-content: space-between;
+}
+
+/* Mobile: everything stacks, nothing scrolls sideways — ui-spec §8. */
+@media (max-width: 767px) {
+  .zg-actions > .zg-btn {
+    flex: 1 1 100%;
+  }
+}

--- a/client/tests/lab-01/app-check-system-failure.test.tsx
+++ b/client/tests/lab-01/app-check-system-failure.test.tsx
@@ -1,9 +1,9 @@
 import { act } from 'react'
 import { createRoot } from 'react-dom/client'
 import { afterEach, describe, expect, it, vi } from 'vitest'
-import App from '../../src/App'
+import SystemCheck from '../../src/SystemCheck'
 
-describe('App', () => {
+describe('SystemCheck', () => {
   afterEach(() => {
     vi.unstubAllGlobals()
   })
@@ -18,7 +18,7 @@ describe('App', () => {
     const root = createRoot(container)
 
     act(() => {
-      root.render(<App />)
+      root.render(<SystemCheck />)
     })
 
     await act(async () => {

--- a/client/tests/lab-01/app-check-system-success.test.tsx
+++ b/client/tests/lab-01/app-check-system-success.test.tsx
@@ -1,9 +1,9 @@
 import { act } from 'react'
 import { createRoot } from 'react-dom/client'
 import { afterEach, describe, expect, it, vi } from 'vitest'
-import App from '../../src/App'
+import SystemCheck from '../../src/SystemCheck'
 
-describe('App', () => {
+describe('SystemCheck', () => {
   afterEach(() => {
     vi.unstubAllGlobals()
   })
@@ -30,7 +30,7 @@ describe('App', () => {
     const root = createRoot(container)
 
     act(() => {
-      root.render(<App />)
+      root.render(<SystemCheck />)
     })
 
     await act(async () => {

--- a/client/tests/lab-01/app-initial-render.test.tsx
+++ b/client/tests/lab-01/app-initial-render.test.tsx
@@ -1,16 +1,16 @@
 import { act } from 'react'
 import { createRoot } from 'react-dom/client'
 import { describe, expect, it } from 'vitest'
-import App from '../../src/App'
+import SystemCheck from '../../src/SystemCheck'
 
-describe('App', () => {
+describe('SystemCheck', () => {
   it('renders the check system button with no status shown yet', () => {
     const container = document.createElement('div')
     document.body.appendChild(container)
     const root = createRoot(container)
 
     act(() => {
-      root.render(<App />)
+      root.render(<SystemCheck />)
     })
 
     expect(container.querySelector('h1')).not.toBeNull()

--- a/client/tests/lab-02/DevRequesterSelection.test.tsx
+++ b/client/tests/lab-02/DevRequesterSelection.test.tsx
@@ -1,0 +1,248 @@
+import { cleanup, render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { MemoryRouter } from 'react-router-dom'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { AppRoutes } from '../../src/App'
+import { REQUESTER_STORAGE_KEY, RequesterProvider } from '../../src/RequesterContext'
+
+const activeRequesters = [
+  { id: 4, name: 'Jennifer Anderson', email: 'jennifer.anderson@example.com' },
+  { id: 2, name: 'Michael Brown', email: 'michael.brown@example.com' },
+]
+
+const inactiveRequester = {
+  id: 9,
+  name: 'Patricia Reyes',
+  email: 'patricia.reyes@example.com',
+}
+
+function mockRequesters(body: unknown, status = 200) {
+  vi.stubGlobal(
+    'fetch',
+    vi.fn(() => Promise.resolve(new Response(JSON.stringify(body), { status }))),
+  )
+}
+
+const continueButton = () =>
+  screen.getByRole('button', { name: /continue/i }) as HTMLButtonElement
+
+function renderApp(initialEntry = '/select-requester') {
+  return render(
+    <MemoryRouter initialEntries={[initialEntry]}>
+      <RequesterProvider>
+        <AppRoutes />
+      </RequesterProvider>
+    </MemoryRouter>,
+  )
+}
+
+beforeEach(() => {
+  localStorage.clear()
+})
+
+afterEach(() => {
+  // vitest runs without `globals: true` here, so RTL's auto-cleanup never registers
+  cleanup()
+  vi.unstubAllGlobals()
+  localStorage.clear()
+})
+
+describe('UI-01 (AC-22): Development Requester Selection lists active requesters only', () => {
+  it('populates the dropdown from the active-requesters endpoint and shows nothing else', async () => {
+    mockRequesters(activeRequesters)
+    renderApp()
+
+    const select = await screen.findByLabelText(/development requester/i)
+    const optionLabels = Array.from(select.querySelectorAll('option')).map((o) => o.textContent)
+
+    expect(optionLabels.join(' ')).toContain('Jennifer Anderson')
+    expect(optionLabels.join(' ')).toContain('Michael Brown')
+    expect(optionLabels.join(' ')).not.toContain(inactiveRequester.name)
+    expect(fetch).toHaveBeenCalledWith('/api/dev-requesters')
+  })
+
+  it('renders requesters in the order the API returned them, without re-sorting', async () => {
+    mockRequesters(activeRequesters)
+    renderApp()
+
+    const select = await screen.findByLabelText(/development requester/i)
+    const values = Array.from(select.querySelectorAll('option'))
+      .map((o) => (o as HTMLOptionElement).value)
+      .filter(Boolean)
+
+    expect(values).toEqual(['4', '2'])
+  })
+
+  it('keeps Continue disabled until a requester is chosen', async () => {
+    const user = userEvent.setup()
+    mockRequesters(activeRequesters)
+    renderApp()
+
+    const select = await screen.findByLabelText(/development requester/i)
+    expect(continueButton().disabled).toBe(true)
+
+    await user.selectOptions(select, '2')
+    expect(continueButton().disabled).toBe(false)
+  })
+
+  it('explains that this is testing only and not a login', async () => {
+    mockRequesters(activeRequesters)
+    renderApp()
+
+    await screen.findByLabelText(/development requester/i)
+    expect(document.body.textContent).toMatch(/not a login screen/i)
+    expect(document.body.textContent).toMatch(/only active development requesters are shown/i)
+  })
+
+  it('is operable by keyboard alone', async () => {
+    const user = userEvent.setup()
+    mockRequesters(activeRequesters)
+    renderApp()
+
+    const select = await screen.findByLabelText(/development requester/i)
+    select.focus()
+    await user.selectOptions(select, '4')
+    await user.tab()
+    expect(document.activeElement).toBe(screen.getByRole('button', { name: /cancel/i }))
+    await user.tab()
+
+    expect(document.activeElement).toBe(continueButton())
+  })
+})
+
+describe('Development Requester Selection loading and empty states', () => {
+  it('shows a loading state with Continue disabled while requesters are fetched', () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(() => new Promise(() => {})),
+    )
+    renderApp()
+
+    expect(screen.getByText(/loading development requesters/i)).toBeTruthy()
+    expect(continueButton().disabled).toBe(true)
+  })
+
+  it('shows an empty state when no active requesters are configured', async () => {
+    mockRequesters([])
+    renderApp()
+
+    expect(await screen.findByText(/no active development requesters/i)).toBeTruthy()
+    expect(screen.queryByLabelText(/development requester/i)).toBeNull()
+    expect(continueButton().disabled).toBe(true)
+  })
+})
+
+describe('UI-02 (AC-21): Development Requester Selection API failure', () => {
+  it('shows a safe error state with a retry action and no dropdown', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(() => Promise.reject(new Error('network down'))),
+    )
+    renderApp()
+
+    const alert = await screen.findByRole('alert')
+    expect(alert.textContent).toMatch(/unable to load development requesters/i)
+    expect(screen.queryByLabelText(/development requester/i)).toBeNull()
+    expect(screen.getByRole('button', { name: /retry/i })).toBeTruthy()
+    expect(continueButton().disabled).toBe(true)
+  })
+
+  it('recovers when retry succeeds', async () => {
+    const user = userEvent.setup()
+    const fetchMock = vi
+      .fn()
+      .mockRejectedValueOnce(new Error('network down'))
+      .mockResolvedValueOnce(new Response(JSON.stringify(activeRequesters), { status: 200 }))
+    vi.stubGlobal('fetch', fetchMock)
+    renderApp()
+
+    await user.click(await screen.findByRole('button', { name: /retry/i }))
+
+    expect(await screen.findByLabelText(/development requester/i)).toBeTruthy()
+    expect(screen.queryByRole('alert')).toBeNull()
+  })
+
+  it('treats a non-ok response as a failure rather than rendering a broken dropdown', async () => {
+    mockRequesters({ error: { code: 'INTERNAL_ERROR' } }, 500)
+    renderApp()
+
+    expect(await screen.findByRole('alert')).toBeTruthy()
+    expect(screen.queryByLabelText(/development requester/i)).toBeNull()
+  })
+})
+
+describe('UI-03 (AC-02, BR-12): requester-scoped screens redirect when nothing is selected', () => {
+  it.each(['/tickets', '/tickets/new', '/tickets/123'])(
+    'redirects %s to the selection screen',
+    async (path) => {
+      mockRequesters(activeRequesters)
+      renderApp(path)
+
+      expect(await screen.findByRole('heading', { name: /select development requester/i })).toBeTruthy()
+    },
+  )
+})
+
+describe('UI-04 (AC-23, BR-11): change requester', () => {
+  it('shows the selected requester in the app shell after Continue', async () => {
+    const user = userEvent.setup()
+    mockRequesters(activeRequesters)
+    renderApp()
+
+    await user.selectOptions(await screen.findByLabelText(/development requester/i), '2')
+    await user.click(screen.getByRole('button', { name: /continue/i }))
+
+    expect((await screen.findByTestId('current-requester')).textContent).toMatch(/michael brown/i)
+    expect(JSON.parse(localStorage.getItem(REQUESTER_STORAGE_KEY) ?? 'null')).toMatchObject({
+      id: 2,
+      name: 'Michael Brown',
+    })
+  })
+
+  it('clears the previous requester and returns to the selection screen', async () => {
+    const user = userEvent.setup()
+    mockRequesters(activeRequesters)
+    localStorage.setItem(REQUESTER_STORAGE_KEY, JSON.stringify(activeRequesters[1]))
+    renderApp('/tickets')
+
+    await user.click(await screen.findByRole('button', { name: /change requester/i }))
+
+    expect(await screen.findByRole('heading', { name: /select development requester/i })).toBeTruthy()
+    expect(localStorage.getItem(REQUESTER_STORAGE_KEY)).toBeNull()
+    expect(screen.queryByTestId('current-requester')).toBeNull()
+  })
+
+  it('replaces the previous requester everywhere after switching', async () => {
+    const user = userEvent.setup()
+    mockRequesters(activeRequesters)
+    localStorage.setItem(REQUESTER_STORAGE_KEY, JSON.stringify(activeRequesters[1]))
+    renderApp('/tickets')
+
+    await user.click(await screen.findByRole('button', { name: /change requester/i }))
+    await user.selectOptions(await screen.findByLabelText(/development requester/i), '4')
+    await user.click(screen.getByRole('button', { name: /continue/i }))
+
+    const current = await screen.findByTestId('current-requester')
+    expect(current.textContent).toMatch(/jennifer anderson/i)
+    expect(current.textContent).not.toMatch(/michael brown/i)
+    expect(screen.queryByText(/michael brown/i)).toBeNull()
+  })
+
+  it('remounts requester-scoped content when the selection changes', async () => {
+    const user = userEvent.setup()
+    mockRequesters(activeRequesters)
+    localStorage.setItem(REQUESTER_STORAGE_KEY, JSON.stringify(activeRequesters[1]))
+    renderApp('/tickets')
+
+    const before = await screen.findByTestId('requester-scope')
+    expect(before.getAttribute('data-requester-id')).toBe('2')
+
+    await user.click(screen.getByRole('button', { name: /change requester/i }))
+    await user.selectOptions(await screen.findByLabelText(/development requester/i), '4')
+    await user.click(screen.getByRole('button', { name: /continue/i }))
+
+    await waitFor(() =>
+      expect(screen.getByTestId('requester-scope').getAttribute('data-requester-id')).toBe('4'),
+    )
+  })
+})

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,6 +6,8 @@ settings:
 
 importers:
 
+  .: {}
+
   client:
     dependencies:
       bootstrap:
@@ -17,7 +19,19 @@ importers:
       react-dom:
         specifier: ^19.2.8
         version: 19.2.8(react@19.2.8)
+      react-router-dom:
+        specifier: ^7.18.3
+        version: 7.18.3(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
     devDependencies:
+      '@testing-library/dom':
+        specifier: ^10.4.1
+        version: 10.4.1
+      '@testing-library/react':
+        specifier: ^16.3.3
+        version: 16.3.3(@testing-library/dom@10.4.1)(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      '@testing-library/user-event':
+        specifier: ^14.6.7
+        version: 14.6.7(@testing-library/dom@10.4.1)
       '@types/node':
         specifier: ^24.13.3
         version: 24.13.3
@@ -101,6 +115,18 @@ packages:
   '@asamuzakjp/dom-selector@8.3.2':
     resolution: {integrity: sha512-93Z1N+BQNXysodoicpOIyNh2drHfz/CTf9nnT0FEx72GJcIiwgydD7tGAr78j41LsYn3hlRn+LdGPuBLn1Bl8Q==}
     engines: {node: ^22.13.0 || >=24.0.0}
+
+  '@babel/code-frame@7.29.7':
+    resolution: {integrity: sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-validator-identifier@7.29.7':
+    resolution: {integrity: sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/runtime@7.29.7':
+    resolution: {integrity: sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==}
+    engines: {node: '>=6.9.0'}
 
   '@bramus/specificity@2.4.2':
     resolution: {integrity: sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw==}
@@ -678,6 +704,34 @@ packages:
   '@standard-schema/spec@1.1.0':
     resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
 
+  '@testing-library/dom@10.4.1':
+    resolution: {integrity: sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==}
+    engines: {node: '>=18'}
+
+  '@testing-library/react@16.3.3':
+    resolution: {integrity: sha512-Uo193NgQbPMz6lrrhtRQQFcMC6Re/ELLFbbuVL30WDlZxlpZf9/lMHTAVxPRLw1q1iu9OJmR1c2BLiENRstdBg==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@testing-library/dom': ^10.0.0
+      '@types/react': ^18.0.0 || ^19.0.0
+      '@types/react-dom': ^18.0.0 || ^19.0.0
+      react: ^18.0.0 || ^19.0.0
+      react-dom: ^18.0.0 || ^19.0.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@testing-library/user-event@14.6.7':
+    resolution: {integrity: sha512-MPCpX8bxe8zS+JmmTwLp8jd0dy1rAm60Te/SL8JrQM3qvQJcBOs1d7IefJMyZzqM3EWBrDn/LWDt1BCGu4ASfg==}
+    engines: {node: '>=12', npm: '>=6'}
+    peerDependencies:
+      '@testing-library/dom': '>=7.21.4'
+
+  '@types/aria-query@5.0.4':
+    resolution: {integrity: sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==}
+
   '@types/body-parser@1.19.6':
     resolution: {integrity: sha512-HLFeCYgz89uk22N5Qg3dvGvsv46B8GLvKKo1zKG4NybA8U2DiEO3w9lqGg29t/tfLRJpJ6iQxnVw4OnB7MoM9g==}
 
@@ -986,6 +1040,17 @@ packages:
   ajv@8.20.0:
     resolution: {integrity: sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==}
 
+  ansi-regex@5.0.1:
+    resolution: {integrity: sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==}
+    engines: {node: '>=8'}
+
+  ansi-styles@5.2.0:
+    resolution: {integrity: sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==}
+    engines: {node: '>=10'}
+
+  aria-query@5.3.0:
+    resolution: {integrity: sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==}
+
   asap@2.0.6:
     resolution: {integrity: sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA==}
 
@@ -1078,6 +1143,10 @@ packages:
   cookie@0.7.2:
     resolution: {integrity: sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==}
     engines: {node: '>= 0.6'}
+
+  cookie@1.1.1:
+    resolution: {integrity: sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==}
+    engines: {node: '>=18'}
 
   cookiejar@2.1.4:
     resolution: {integrity: sha512-LDx6oHrK+PhzLKJU9j5S7/Y3jM/mUHvD/DeI1WQmJn652iPC5Y4TBzC9l+5OMOXlyTTA+SmVUPm0HQUwpD5Jqw==}
@@ -1179,6 +1248,10 @@ packages:
     resolution: {integrity: sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==}
     engines: {node: '>= 0.8'}
 
+  dequal@2.0.3:
+    resolution: {integrity: sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==}
+    engines: {node: '>=6'}
+
   destr@2.0.5:
     resolution: {integrity: sha512-ugFTXCtDZunbzasqBxrK93Ik/DRYsO6S/fedkWEMKqt04xZ4csmnmwGDBAb07QWNaGMAmnTIemsYZCksjATwsA==}
 
@@ -1188,6 +1261,9 @@ packages:
 
   dezalgo@1.0.4:
     resolution: {integrity: sha512-rXSP0bf+5n0Qonsb+SVVfNfIsimO4HEtmnIpPHY8Q1UCzKlQrDMfdobr8nJOOsRgWCyMRqeSBQzmWUMq7zvVig==}
+
+  dom-accessibility-api@0.5.16:
+    resolution: {integrity: sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==}
 
   dotenv@17.4.2:
     resolution: {integrity: sha512-nI4U3TottKAcAD9LLud4Cb7b2QztQMUEfHbvhTH09bqXTxnSie8WnjPALV/WMCrJZ6UV/qHJ6L03OqO3LcdYZw==}
@@ -1413,6 +1489,9 @@ packages:
     resolution: {integrity: sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ==}
     hasBin: true
 
+  js-tokens@4.0.0:
+    resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
+
   jsdom@30.0.1:
     resolution: {integrity: sha512-52v7mUVUfNQVYYqE1lcdaymWL0njO7lTLUog6ZvW2U5KsbiLk/GnZlVJ+qx0xfNJZ6Gn+KSpPNE52vurbxZwrA==}
     engines: {node: ^22.22.2 || ^24.15.0 || >=26.0.0}
@@ -1508,6 +1587,10 @@ packages:
   lru.min@1.1.4:
     resolution: {integrity: sha512-DqC6n3QQ77zdFpCMASA1a3Jlb64Hv2N2DciFGkO/4L9+q/IpIAuRlKOvCXabtRW6cQf8usbmM6BE/TOPysCdIA==}
     engines: {bun: '>=1.0.0', deno: '>=1.30.0', node: '>=8.0.0'}
+
+  lz-string@1.5.0:
+    resolution: {integrity: sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==}
+    hasBin: true
 
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
@@ -1695,6 +1778,10 @@ packages:
     resolution: {integrity: sha512-Jtc2612XINuBjIl/QTWsV5UvE8UHuNblcO3vVADSrKsrc6RqGX6lOW1cEo3CM2v0XG4Nat8nI+YM7/f26VxXLw==}
     engines: {node: '>=12'}
 
+  pretty-format@27.5.1:
+    resolution: {integrity: sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==}
+    engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
+
   prisma@7.9.1:
     resolution: {integrity: sha512-aPqePoZIqwlAchbgbFDO/wHqGB+7H1nj9gaM+OsL9h77S5S3TnLd9BgD3LnoeDikULo7cl2HSUrEyQ55Z7DYbg==}
     engines: {node: ^20.19 || ^22.12 || >=24.0}
@@ -1741,6 +1828,26 @@ packages:
     resolution: {integrity: sha512-rVprimfGBG3DR+Tq0IQG2DT5PxKth1WIGDmj5yPmlzr4YBe7uyE+Du4oVqTDXZSHGGGXRtTJEGSSePyQCMBglQ==}
     peerDependencies:
       react: ^19.2.8
+
+  react-is@17.0.2:
+    resolution: {integrity: sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==}
+
+  react-router-dom@7.18.3:
+    resolution: {integrity: sha512-ytVbyBBM7vMfRCam25r0WMhSVSom909A8p+8m0/f1w853dz/xfFu6etAT2SEbVoSnI+ZoPRDqIsQXVT89gp7kg==}
+    engines: {node: '>=20.0.0'}
+    peerDependencies:
+      react: '>=18'
+      react-dom: '>=18'
+
+  react-router@7.18.3:
+    resolution: {integrity: sha512-gyXgtdr5uACJ5b1Q4udzjVV+tb/rlHIMJKuJ0e89R4Kzgz47z/rgP0dIKxktqIEUhDHluGTPJJH/wRha7CyqsA==}
+    engines: {node: '>=20.0.0'}
+    peerDependencies:
+      react: '>=18'
+      react-dom: '>=18'
+    peerDependenciesMeta:
+      react-dom:
+        optional: true
 
   react@19.2.8:
     resolution: {integrity: sha512-PWaYA1L/q9u2u7xYQi+Y3L3Yfnie7XyLeaJICV1MGD6LprsBxcAqGjYyr0eY3p+QdsA+x/Irkt4Qif8D63+Sbw==}
@@ -1801,6 +1908,9 @@ packages:
   serve-static@2.2.1:
     resolution: {integrity: sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==}
     engines: {node: '>= 18'}
+
+  set-cookie-parser@2.7.2:
+    resolution: {integrity: sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw==}
 
   setprototypeof@1.2.0:
     resolution: {integrity: sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==}
@@ -2101,6 +2211,16 @@ snapshots:
       css-tree: 3.2.1
       is-potential-custom-element-name: 1.0.1
       lru-cache: 11.5.2
+
+  '@babel/code-frame@7.29.7':
+    dependencies:
+      '@babel/helper-validator-identifier': 7.29.7
+      js-tokens: 4.0.0
+      picocolors: 1.1.1
+
+  '@babel/helper-validator-identifier@7.29.7': {}
+
+  '@babel/runtime@7.29.7': {}
 
   '@bramus/specificity@2.4.2':
     dependencies:
@@ -2499,6 +2619,33 @@ snapshots:
 
   '@standard-schema/spec@1.1.0': {}
 
+  '@testing-library/dom@10.4.1':
+    dependencies:
+      '@babel/code-frame': 7.29.7
+      '@babel/runtime': 7.29.7
+      '@types/aria-query': 5.0.4
+      aria-query: 5.3.0
+      dom-accessibility-api: 0.5.16
+      lz-string: 1.5.0
+      picocolors: 1.1.1
+      pretty-format: 27.5.1
+
+  '@testing-library/react@16.3.3(@testing-library/dom@10.4.1)(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)':
+    dependencies:
+      '@babel/runtime': 7.29.7
+      '@testing-library/dom': 10.4.1
+      react: 19.2.8
+      react-dom: 19.2.8(react@19.2.8)
+    optionalDependencies:
+      '@types/react': 19.2.18
+      '@types/react-dom': 19.2.4(@types/react@19.2.18)
+
+  '@testing-library/user-event@14.6.7(@testing-library/dom@10.4.1)':
+    dependencies:
+      '@testing-library/dom': 10.4.1
+
+  '@types/aria-query@5.0.4': {}
+
   '@types/body-parser@1.19.6':
     dependencies:
       '@types/connect': 3.4.38
@@ -2820,6 +2967,14 @@ snapshots:
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
 
+  ansi-regex@5.0.1: {}
+
+  ansi-styles@5.2.0: {}
+
+  aria-query@5.3.0:
+    dependencies:
+      dequal: 2.0.3
+
   asap@2.0.6: {}
 
   assertion-error@2.0.1: {}
@@ -2906,6 +3061,8 @@ snapshots:
   cookie-signature@1.2.2: {}
 
   cookie@0.7.2: {}
+
+  cookie@1.1.1: {}
 
   cookiejar@2.1.4: {}
 
@@ -2995,6 +3152,8 @@ snapshots:
 
   depd@2.0.0: {}
 
+  dequal@2.0.3: {}
+
   destr@2.0.5: {}
 
   detect-libc@2.1.2: {}
@@ -3003,6 +3162,8 @@ snapshots:
     dependencies:
       asap: 2.0.6
       wrappy: 1.0.2
+
+  dom-accessibility-api@0.5.16: {}
 
   dotenv@17.4.2: {}
 
@@ -3263,6 +3424,8 @@ snapshots:
 
   jiti@2.7.0: {}
 
+  js-tokens@4.0.0: {}
+
   jsdom@30.0.1(@noble/hashes@1.8.0):
     dependencies:
       '@asamuzakjp/css-color': 6.0.7
@@ -3347,6 +3510,8 @@ snapshots:
   lru-cache@11.5.2: {}
 
   lru.min@1.1.4: {}
+
+  lz-string@1.5.0: {}
 
   magic-string@0.30.21:
     dependencies:
@@ -3513,6 +3678,12 @@ snapshots:
 
   postgres@3.4.7: {}
 
+  pretty-format@27.5.1:
+    dependencies:
+      ansi-regex: 5.0.1
+      ansi-styles: 5.2.0
+      react-is: 17.0.2
+
   prisma@7.9.1(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(typescript@7.0.2):
     dependencies:
       '@prisma/config': 7.9.1
@@ -3568,6 +3739,22 @@ snapshots:
     dependencies:
       react: 19.2.8
       scheduler: 0.27.0
+
+  react-is@17.0.2: {}
+
+  react-router-dom@7.18.3(react-dom@19.2.8(react@19.2.8))(react@19.2.8):
+    dependencies:
+      react: 19.2.8
+      react-dom: 19.2.8(react@19.2.8)
+      react-router: 7.18.3(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+
+  react-router@7.18.3(react-dom@19.2.8(react@19.2.8))(react@19.2.8):
+    dependencies:
+      cookie: 1.1.1
+      react: 19.2.8
+      set-cookie-parser: 2.7.2
+    optionalDependencies:
+      react-dom: 19.2.8(react@19.2.8)
 
   react@19.2.8: {}
 
@@ -3651,6 +3838,8 @@ snapshots:
       send: 1.2.1
     transitivePeerDependencies:
       - supports-color
+
+  set-cookie-parser@2.7.2: {}
 
   setprototypeof@1.2.0: {}
 

--- a/server/prisma/migrations/20260902174250_add_requester_user/migration.sql
+++ b/server/prisma/migrations/20260902174250_add_requester_user/migration.sql
@@ -1,0 +1,13 @@
+-- CreateTable
+CREATE TABLE "RequesterUser" (
+    "id" SERIAL NOT NULL,
+    "name" TEXT NOT NULL,
+    "email" TEXT NOT NULL,
+    "isActive" BOOLEAN NOT NULL DEFAULT true,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "RequesterUser_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "RequesterUser_email_key" ON "RequesterUser"("email");

--- a/server/prisma/schema.prisma
+++ b/server/prisma/schema.prisma
@@ -17,3 +17,13 @@ model Category {
   name      String   @unique
   createdAt DateTime @default(now())
 }
+
+// Lab 2 temporary testing identity, not an authenticated user (BR-03).
+// Lab 3 replaces this with a real account model; see specification.md §7.3.
+model RequesterUser {
+  id        Int      @id @default(autoincrement())
+  name      String
+  email     String   @unique
+  isActive  Boolean  @default(true)
+  createdAt DateTime @default(now())
+}

--- a/server/prisma/seed.ts
+++ b/server/prisma/seed.ts
@@ -7,12 +7,32 @@ const prisma = new PrismaClient({ adapter });
 
 const categories = ["Account and Access", "Hardware", "Software", "Network"];
 
+// Lab 2 Development Requesters (specification.md §7.4): 4 active + 1 inactive.
+// The inactive one must never reach the selection dropdown (BR-09/AC-22).
+const requesters = [
+  { name: "Jennifer Anderson", email: "jennifer.anderson@example.com", isActive: true },
+  { name: "Michael Brown", email: "michael.brown@example.com", isActive: true },
+  { name: "Siriporn Wattana", email: "siriporn.wattana@example.com", isActive: true },
+  { name: "David Chen", email: "david.chen@example.com", isActive: true },
+  { name: "Patricia Reyes", email: "patricia.reyes@example.com", isActive: false },
+];
+
 async function main() {
   for (const name of categories) {
     await prisma.category.upsert({
       where: { name },
       update: {},
       create: { name },
+    });
+  }
+
+  // Re-runnable: keyed on the unique email, and isActive is re-applied so an
+  // edited seed row converges instead of drifting.
+  for (const requester of requesters) {
+    await prisma.requesterUser.upsert({
+      where: { email: requester.email },
+      update: { name: requester.name, isActive: requester.isActive },
+      create: requester,
     });
   }
 }

--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -13,3 +13,22 @@ app.get('/api/categories', async (_req, res) => {
   const categories = await prisma.category.findMany({ orderBy: { id: 'asc' } })
   res.json(categories)
 })
+
+// Lab 2 testing identities, not authentication (BR-03). Only active rows,
+// ordered by name (BR-09); isActive is never exposed to the client.
+app.get('/api/dev-requesters', async (_req, res) => {
+  const requesters = await prisma.requesterUser.findMany({
+    where: { isActive: true },
+    orderBy: { name: 'asc' },
+    select: { id: true, name: true, email: true },
+  })
+  res.json(requesters)
+})
+
+// Standard error envelope (api-spec.md §0.2). Never leaks internals.
+app.use((err: unknown, _req: express.Request, res: express.Response, _next: express.NextFunction) => {
+  console.error(err)
+  res.status(500).json({
+    error: { code: 'INTERNAL_ERROR', message: 'Something went wrong. Please try again.' },
+  })
+})

--- a/server/tests/lab-02/dev-requesters.api.test.ts
+++ b/server/tests/lab-02/dev-requesters.api.test.ts
@@ -1,0 +1,58 @@
+import request from 'supertest'
+import { afterAll, beforeAll, describe, expect, it } from 'vitest'
+import { app } from '../../src/app.js'
+import { prisma } from '../../src/db.js'
+
+// API-24 (AC-22, BR-09): GET /api/dev-requesters returns only active
+// requesters, ordered by name ascending.
+//
+// Fixture rows are created and removed by this file so the assertions don't
+// depend on whatever the seed happens to have left in the dev database.
+const fixtures = [
+  { name: 'Zzz Fixture Active', email: 'zzz.fixture.active@test.invalid', isActive: true },
+  { name: 'Aaa Fixture Active', email: 'aaa.fixture.active@test.invalid', isActive: true },
+  { name: 'Mmm Fixture Inactive', email: 'mmm.fixture.inactive@test.invalid', isActive: false },
+]
+
+const emails = fixtures.map((f) => f.email)
+
+beforeAll(async () => {
+  await prisma.requesterUser.deleteMany({ where: { email: { in: emails } } })
+  for (const fixture of fixtures) {
+    await prisma.requesterUser.create({ data: fixture })
+  }
+})
+
+afterAll(async () => {
+  await prisma.requesterUser.deleteMany({ where: { email: { in: emails } } })
+})
+
+describe('GET /api/dev-requesters', () => {
+  it('returns only active requesters', async () => {
+    const res = await request(app).get('/api/dev-requesters')
+
+    expect(res.status).toBe(200)
+    const returnedEmails = res.body.map((r: { email: string }) => r.email)
+    expect(returnedEmails).toContain('aaa.fixture.active@test.invalid')
+    expect(returnedEmails).toContain('zzz.fixture.active@test.invalid')
+    expect(returnedEmails).not.toContain('mmm.fixture.inactive@test.invalid')
+  })
+
+  it('orders requesters by name ascending', async () => {
+    const res = await request(app).get('/api/dev-requesters')
+
+    const names = res.body.map((r: { name: string }) => r.name)
+    expect(names).toEqual([...names].sort((a: string, b: string) => a.localeCompare(b)))
+  })
+
+  it('exposes id, name and email but never the isActive flag', async () => {
+    const res = await request(app).get('/api/dev-requesters')
+
+    const row = res.body.find(
+      (r: { email: string }) => r.email === 'aaa.fixture.active@test.invalid',
+    )
+    expect(row).toMatchObject({ name: 'Aaa Fixture Active', email: 'aaa.fixture.active@test.invalid' })
+    expect(typeof row.id).toBe('number')
+    expect(Object.keys(row).sort()).toEqual(['email', 'id', 'name'])
+  })
+})


### PR DESCRIPTION
Closes #18.

Implements the Development Requester selection flow. There is no authentication here. The selected identity lives in localStorage, and every future API call still has to send the id explicitly (BR-10).

## What's in it

`RequesterUser` model plus migration, with `isActive`. The seed adds 4 active requesters and 1 inactive, keyed on unique email so re-running it converges instead of duplicating. I ran it three times and got 5 rows, 4 active, every time.

`GET /api/dev-requesters` returns active rows only, sorted by name, and never exposes `isActive`. The client does not re-sort. BR-09 ordering is the API's job, and a test pins that.

The selection screen covers loading, empty, and API failure, with a retry that recovers. It is keyboard operable, the label is associated with the select, and focus outlines are left alone.

The app shell shows the current requester name and a Change Requester action. Requester-scoped routes are keyed on the requester id, so switching remounts them and their data reloads (FR-13). `/tickets`, `/tickets/new` and `/tickets/:id` redirect to the selection screen when nothing is stored (BR-12). Those three render placeholders for now. The routes exist so the guard has something to guard.

Lab 1's Check System screen moved to `SystemCheck.tsx` at `/system-check`. The three lab-01 tests changed import path and identifier only, no assertions touched.

## Tests

server 5/5, client 23/23.

| Planned test | Result |
| --- | --- |
| API-24 (AC-22) | pass |
| UI-01 (AC-22) | pass |
| UI-02 (AC-21) | pass |
| UI-03 (AC-02) | pass |
| UI-04 (AC-23) | partial |

AC-22, AC-21 and AC-02 are done. AC-23 is half done. The context and storage clear, the shell shows the new requester, and scoped content remounts. Proving that the old requester's ticket data disappears needs My Tickets to exist first.

I falsified both load-bearing behaviors rather than trusting a green run. Dropping the `isActive` filter fails API-24. Dropping `<Navigate>` fails all three UI-03 cases.

API-25 and UNIT-03 are not here. API-25 needs `Category.isActive` and `/api/related-systems`. UNIT-03 would be a helper with no callers, since nothing takes a `requesterId` yet.

## Deviations from ui-spec

The one worth arguing about is the mobile nav. There is no hamburger. The header wraps instead. Two nav links do not justify a collapse menu, and BR-11 wants Change Requester reachable at all times, which an always-visible button does better than a menu. The same reasoning flattened the "Profile-style menu" into a plain button.

Smaller ones. Cancel resets the dropdown rather than navigating, since the screen has nowhere to go back to. Options read `Name (email)` so near-identical test names stay apart. Icons are emoji with `aria-hidden`, which avoids pulling in an icon library.

## Gap worth flagging

BR-12 has a third branch I did not implement, the case where a stored requester has since gone inactive. Nothing revalidates localStorage against the API right now. It will fall out of the first endpoint that returns `INVALID_REQUESTER`. Adding a revalidation fetch on restore costs a second request on every load for a case only reachable by editing seed data mid-session, so I left it out. Easy to add if you disagree.

