### PR TITLE
feat: Ticket, Attachment and RelatedSystem schema

### DIFF
--- a/docs/lab-02/tests.md
+++ b/docs/lab-02/tests.md
@@ -32,6 +32,14 @@ is covered by at least one row (§3 matrix).
 
 | Test ID | Type | Requirement / AC | What It Tests | Expected Result | Automated Test File | Final |
 | --- | --- | --- | --- | --- | --- | --- |
+| SCHEMA-01 | Integration | BR-01 | `Ticket.ticketNumber` unique constraint | A second insert with the same ticket number is rejected by the database | `server/tests/lab-02/schema.integration.test.ts` | Pass |
+| SCHEMA-02 | Integration | BR-02, BR-04 | `Ticket` system-generated defaults | `currentStatus` defaults to `NEW`; `createdAt`/`updatedAt` are stamped without being supplied | `server/tests/lab-02/schema.integration.test.ts` | Pass |
+| SCHEMA-03 | Integration | BR-07, BR-13 | `Ticket` foreign-key integrity | Insert with an unknown `requesterId`, `categoryId` or `relatedSystemId` is rejected | `server/tests/lab-02/schema.integration.test.ts` | Pass |
+| SCHEMA-04 | Integration | specification.md §7.2 | Column nullability | Required Ticket/Attachment columns are `NOT NULL`; `removedAt`/`removedReason` are nullable | `server/tests/lab-02/schema.integration.test.ts` | Pass |
+| SCHEMA-05 | Integration | BR-17, BR-18 | Search/filter/sort index coverage | Indexes exist on `requesterId`, `categoryId`, `relatedSystemId`, `currentStatus`, `createdAt` | `server/tests/lab-02/schema.integration.test.ts` | Pass |
+| SCHEMA-06 | Integration | BR-27 | Attachment soft-removal defaults and ticket cascade | New attachments start `isRemoved: false` with null removal fields; deleting a Ticket removes its Attachment rows | `server/tests/lab-02/schema.integration.test.ts` | Pass |
+| SCHEMA-07 | Integration | BR-07, BR-13 | Reference and requester rows in use | Deleting a Category, Related System or Requester still referenced by a Ticket is refused | `server/tests/lab-02/schema.integration.test.ts` | Pass |
+| SCHEMA-08 | Integration | specification.md §7.4 | Seed idempotency | Seeds the 4 Categories and 7 Related Systems as active; a second run yields identical rows and ids | `server/tests/lab-02/seed-idempotency.integration.test.ts` | Pass |
 | UNIT-01 | Unit | BR-06, AC-01 | Ticket Number generator | Returns `TKT-<year>-<6-digit>` from a given id/year | `server/tests/lab-02/ticket-number.unit.test.ts` | Planned |
 | UNIT-02 | Unit | BR-25 | Attachment filename/type validator | Accepts jpg/jpeg/png/webp/pdf, rejects everything else and path-unsafe names | `server/tests/lab-02/attachment-filename.unit.test.ts` | Planned |
 | UNIT-03 | Unit | BR-10, BR-12 | Requester-context resolver | Rejects a `requesterId` that is missing, unknown, or inactive | `server/tests/lab-02/requester-context.unit.test.ts` | Planned |

--- a/server/prisma/migrations/20260903055355_add_ticket_attachment_related_system/migration.sql
+++ b/server/prisma/migrations/20260903055355_add_ticket_attachment_related_system/migration.sql
@@ -1,0 +1,93 @@
+-- CreateEnum
+CREATE TYPE "RequestedPriority" AS ENUM ('LOW', 'MEDIUM', 'HIGH');
+
+-- CreateEnum
+CREATE TYPE "TicketStatus" AS ENUM ('NEW', 'OPEN', 'IN_PROGRESS', 'PENDING', 'RESOLVED', 'CLOSED', 'CANCELLED');
+
+-- AlterTable
+ALTER TABLE "Category" ADD COLUMN     "isActive" BOOLEAN NOT NULL DEFAULT true;
+
+-- CreateTable
+CREATE TABLE "RelatedSystem" (
+    "id" SERIAL NOT NULL,
+    "name" TEXT NOT NULL,
+    "isActive" BOOLEAN NOT NULL DEFAULT true,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "RelatedSystem_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "Ticket" (
+    "id" SERIAL NOT NULL,
+    "ticketNumber" TEXT NOT NULL,
+    "requesterId" INTEGER NOT NULL,
+    "categoryId" INTEGER NOT NULL,
+    "relatedSystemId" INTEGER NOT NULL,
+    "summary" TEXT NOT NULL,
+    "description" TEXT NOT NULL,
+    "requestedPriority" "RequestedPriority" NOT NULL,
+    "currentStatus" "TicketStatus" NOT NULL DEFAULT 'NEW',
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "Ticket_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "Attachment" (
+    "id" SERIAL NOT NULL,
+    "ticketId" INTEGER NOT NULL,
+    "originalFileName" TEXT NOT NULL,
+    "storedFileName" TEXT NOT NULL,
+    "mimeType" TEXT NOT NULL,
+    "sizeBytes" INTEGER NOT NULL,
+    "uploadedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "isRemoved" BOOLEAN NOT NULL DEFAULT false,
+    "removedAt" TIMESTAMP(3),
+    "removedReason" TEXT,
+
+    CONSTRAINT "Attachment_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "RelatedSystem_name_key" ON "RelatedSystem"("name");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "Ticket_ticketNumber_key" ON "Ticket"("ticketNumber");
+
+-- CreateIndex
+CREATE INDEX "Ticket_requesterId_idx" ON "Ticket"("requesterId");
+
+-- CreateIndex
+CREATE INDEX "Ticket_categoryId_idx" ON "Ticket"("categoryId");
+
+-- CreateIndex
+CREATE INDEX "Ticket_relatedSystemId_idx" ON "Ticket"("relatedSystemId");
+
+-- CreateIndex
+CREATE INDEX "Ticket_currentStatus_idx" ON "Ticket"("currentStatus");
+
+-- CreateIndex
+CREATE INDEX "Ticket_createdAt_idx" ON "Ticket"("createdAt");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "Attachment_storedFileName_key" ON "Attachment"("storedFileName");
+
+-- CreateIndex
+CREATE INDEX "Attachment_ticketId_idx" ON "Attachment"("ticketId");
+
+-- CreateIndex
+CREATE INDEX "Attachment_ticketId_isRemoved_idx" ON "Attachment"("ticketId", "isRemoved");
+
+-- AddForeignKey
+ALTER TABLE "Ticket" ADD CONSTRAINT "Ticket_requesterId_fkey" FOREIGN KEY ("requesterId") REFERENCES "RequesterUser"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Ticket" ADD CONSTRAINT "Ticket_categoryId_fkey" FOREIGN KEY ("categoryId") REFERENCES "Category"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Ticket" ADD CONSTRAINT "Ticket_relatedSystemId_fkey" FOREIGN KEY ("relatedSystemId") REFERENCES "RelatedSystem"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Attachment" ADD CONSTRAINT "Attachment_ticketId_fkey" FOREIGN KEY ("ticketId") REFERENCES "Ticket"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/server/prisma/schema.prisma
+++ b/server/prisma/schema.prisma
@@ -15,7 +15,20 @@ datasource db {
 model Category {
   id        Int      @id @default(autoincrement())
   name      String   @unique
+  isActive  Boolean  @default(true)
   createdAt DateTime @default(now())
+
+  tickets Ticket[]
+}
+
+// Mirrors Category: a simple admin-managed reference list (specification.md §7.3).
+model RelatedSystem {
+  id        Int      @id @default(autoincrement())
+  name      String   @unique
+  isActive  Boolean  @default(true)
+  createdAt DateTime @default(now())
+
+  tickets Ticket[]
 }
 
 // Lab 2 temporary testing identity, not an authenticated user (BR-03).
@@ -26,4 +39,68 @@ model RequesterUser {
   email     String   @unique
   isActive  Boolean  @default(true)
   createdAt DateTime @default(now())
+
+  tickets Ticket[]
+}
+
+enum RequestedPriority {
+  LOW
+  MEDIUM
+  HIGH
+}
+
+// Lab 2 only ever writes NEW; the rest exist so seed data can exercise the
+// My Tickets filter/sort/badge paths (specification.md §11-8).
+enum TicketStatus {
+  NEW
+  OPEN
+  IN_PROGRESS
+  PENDING
+  RESOLVED
+  CLOSED
+  CANCELLED
+}
+
+model Ticket {
+  id                Int               @id @default(autoincrement())
+  ticketNumber      String            @unique
+  requesterId       Int
+  requester         RequesterUser     @relation(fields: [requesterId], references: [id])
+  categoryId        Int
+  category          Category          @relation(fields: [categoryId], references: [id])
+  relatedSystemId   Int
+  relatedSystem     RelatedSystem     @relation(fields: [relatedSystemId], references: [id])
+  summary           String
+  description       String
+  requestedPriority RequestedPriority
+  currentStatus     TicketStatus      @default(NEW)
+  createdAt         DateTime          @default(now())
+  updatedAt         DateTime          @updatedAt
+
+  attachments Attachment[]
+
+  @@index([requesterId])
+  @@index([categoryId])
+  @@index([relatedSystemId])
+  @@index([currentStatus])
+  @@index([createdAt])
+}
+
+// Removal is soft (BR-27/BR-28): the row and its metadata survive so Ticket
+// Detail can still list it, but nothing downloadable is served for it.
+model Attachment {
+  id               Int       @id @default(autoincrement())
+  ticketId         Int
+  ticket           Ticket    @relation(fields: [ticketId], references: [id], onDelete: Cascade)
+  originalFileName String
+  storedFileName   String    @unique
+  mimeType         String
+  sizeBytes        Int
+  uploadedAt       DateTime  @default(now())
+  isRemoved        Boolean   @default(false)
+  removedAt        DateTime?
+  removedReason    String?
+
+  @@index([ticketId])
+  @@index([ticketId, isRemoved])
 }

--- a/server/prisma/seed.ts
+++ b/server/prisma/seed.ts
@@ -7,6 +7,17 @@ const prisma = new PrismaClient({ adapter });
 
 const categories = ["Account and Access", "Hardware", "Software", "Network"];
 
+// Related Systems (specification.md §7.4).
+const relatedSystems = [
+  "Email",
+  "Campus Wi-Fi",
+  "VPN",
+  "LEB2 App",
+  "Grade Submission App",
+  "Printer",
+  "Corporate Laptop",
+];
+
 // Lab 2 Development Requesters (specification.md §7.4): 4 active + 1 inactive.
 // The inactive one must never reach the selection dropdown (BR-09/AC-22).
 const requesters = [
@@ -18,10 +29,20 @@ const requesters = [
 ];
 
 async function main() {
+  // Re-runnable and convergent: isActive is re-applied so a row deactivated
+  // by hand returns to the seeded state, matching the requester loop below.
   for (const name of categories) {
     await prisma.category.upsert({
       where: { name },
-      update: {},
+      update: { isActive: true },
+      create: { name },
+    });
+  }
+
+  for (const name of relatedSystems) {
+    await prisma.relatedSystem.upsert({
+      where: { name },
+      update: { isActive: true },
       create: { name },
     });
   }

--- a/server/tests/lab-02/schema.integration.test.ts
+++ b/server/tests/lab-02/schema.integration.test.ts
@@ -1,0 +1,139 @@
+import { afterAll, beforeAll, describe, expect, it } from 'vitest'
+import { prisma } from '../../src/db.js'
+
+// SCHEMA-01..05 — database-level guarantees for the Lab 2 ticketing schema
+// (specification.md §7.1–§7.3). These assert what the DB enforces on its own,
+// independent of any route handler or validation layer.
+
+const TAG = 'schema.test.invalid'
+
+let categoryId: number
+let relatedSystemId: number
+let requesterId: number
+
+async function wipe() {
+  await prisma.ticket.deleteMany({ where: { summary: { contains: TAG } } })
+  await prisma.category.deleteMany({ where: { name: { contains: TAG } } })
+  await prisma.relatedSystem.deleteMany({ where: { name: { contains: TAG } } })
+  await prisma.requesterUser.deleteMany({ where: { email: { contains: TAG } } })
+}
+
+function newTicket(overrides: Record<string, unknown> = {}) {
+  return {
+    ticketNumber: `TKT-2026-${String(Math.floor(Math.random() * 1e6)).padStart(6, '0')}`,
+    requesterId,
+    categoryId,
+    relatedSystemId,
+    requestedPriority: 'MEDIUM' as const,
+    summary: `Fixture ticket ${TAG}`,
+    description: 'A description long enough to look like a real ticket body.',
+    ...overrides,
+  }
+}
+
+beforeAll(async () => {
+  await wipe()
+  categoryId = (await prisma.category.create({ data: { name: `Category ${TAG}` } })).id
+  relatedSystemId = (await prisma.relatedSystem.create({ data: { name: `System ${TAG}` } })).id
+  requesterId = (
+    await prisma.requesterUser.create({
+      data: { name: 'Schema Fixture', email: `requester.${TAG}` },
+    })
+  ).id
+})
+
+afterAll(wipe)
+
+describe('Ticket constraints', () => {
+  it('SCHEMA-01 (BR-01): rejects a duplicate ticketNumber', async () => {
+    const ticketNumber = `TKT-2026-999001`
+    await prisma.ticket.create({ data: newTicket({ ticketNumber }) })
+
+    await expect(prisma.ticket.create({ data: newTicket({ ticketNumber }) })).rejects.toMatchObject(
+      { code: 'P2002' },
+    )
+  })
+
+  it('SCHEMA-02 (BR-02): defaults currentStatus to NEW and stamps createdAt/updatedAt', async () => {
+    const ticket = await prisma.ticket.create({ data: newTicket() })
+
+    expect(ticket.currentStatus).toBe('NEW')
+    expect(ticket.createdAt).toBeInstanceOf(Date)
+    expect(ticket.updatedAt).toBeInstanceOf(Date)
+  })
+
+  it('SCHEMA-03: rejects a ticket whose requester, category or related system does not exist', async () => {
+    for (const bad of [{ requesterId: -1 }, { categoryId: -1 }, { relatedSystemId: -1 }]) {
+      await expect(prisma.ticket.create({ data: newTicket(bad) })).rejects.toMatchObject({
+        code: 'P2003',
+      })
+    }
+  })
+
+  it('SCHEMA-04: required columns are NOT NULL, optional ones are nullable', async () => {
+    const columns = await prisma.$queryRaw<{ column_name: string; is_nullable: string }[]>`
+      SELECT column_name, is_nullable FROM information_schema.columns
+      WHERE table_name IN ('Ticket', 'Attachment')
+    `
+    const nullable = Object.fromEntries(columns.map((c) => [c.column_name, c.is_nullable === 'YES']))
+
+    for (const required of ['ticketNumber', 'summary', 'description', 'requesterId', 'categoryId',
+      'relatedSystemId', 'requestedPriority', 'currentStatus', 'originalFileName',
+      'storedFileName', 'mimeType', 'sizeBytes', 'isRemoved']) {
+      expect(nullable[required], `${required} should be NOT NULL`).toBe(false)
+    }
+    for (const optional of ['removedAt', 'removedReason']) {
+      expect(nullable[optional], `${optional} should be nullable`).toBe(true)
+    }
+  })
+
+  it('SCHEMA-05: indexes exist on the columns My Tickets filters and sorts by', async () => {
+    const indexes = await prisma.$queryRaw<{ indexdef: string }[]>`
+      SELECT indexdef FROM pg_indexes WHERE tablename = 'Ticket'
+    `
+    const defs = indexes.map((i) => i.indexdef).join('\n')
+
+    for (const column of ['requesterId', 'categoryId', 'relatedSystemId', 'currentStatus', 'createdAt']) {
+      expect(defs, `expected an index covering ${column}`).toContain(`"${column}"`)
+    }
+  })
+})
+
+describe('delete behaviour', () => {
+  it('SCHEMA-06: deleting a ticket cascades to its attachments', async () => {
+    const ticket = await prisma.ticket.create({ data: newTicket() })
+    const attachment = await prisma.attachment.create({
+      data: {
+        ticketId: ticket.id,
+        originalFileName: 'evidence.pdf',
+        storedFileName: `${TAG}-${ticket.id}.pdf`,
+        mimeType: 'application/pdf',
+        sizeBytes: 1024,
+      },
+    })
+
+    expect(attachment.isRemoved).toBe(false)
+    expect(attachment.removedAt).toBeNull()
+    expect(attachment.removedReason).toBeNull()
+
+    await prisma.ticket.delete({ where: { id: ticket.id } })
+
+    expect(await prisma.attachment.findUnique({ where: { id: attachment.id } })).toBeNull()
+  })
+
+  it('SCHEMA-07: refuses to delete a category, related system or requester still in use', async () => {
+    const ticket = await prisma.ticket.create({ data: newTicket() })
+
+    await expect(prisma.category.delete({ where: { id: categoryId } })).rejects.toMatchObject({
+      code: 'P2003',
+    })
+    await expect(
+      prisma.relatedSystem.delete({ where: { id: relatedSystemId } }),
+    ).rejects.toMatchObject({ code: 'P2003' })
+    await expect(
+      prisma.requesterUser.delete({ where: { id: requesterId } }),
+    ).rejects.toMatchObject({ code: 'P2003' })
+
+    await prisma.ticket.delete({ where: { id: ticket.id } })
+  })
+})

--- a/server/tests/lab-02/seed-idempotency.integration.test.ts
+++ b/server/tests/lab-02/seed-idempotency.integration.test.ts
@@ -1,0 +1,39 @@
+import { execFileSync } from 'node:child_process'
+import { fileURLToPath } from 'node:url'
+import { describe, expect, it } from 'vitest'
+import { prisma } from '../../src/db.js'
+
+// SCHEMA-08 (specification.md §7.4): the seed is re-runnable. Running it a
+// second time must converge on the same rows, never duplicate them.
+
+const serverDir = fileURLToPath(new URL('../..', import.meta.url))
+
+function runSeed() {
+  execFileSync('pnpm', ['exec', 'tsx', 'prisma/seed.ts'], { cwd: serverDir, stdio: 'pipe' })
+}
+
+async function snapshot() {
+  return {
+    categories: await prisma.category.findMany({ orderBy: { id: 'asc' } }),
+    relatedSystems: await prisma.relatedSystem.findMany({ orderBy: { id: 'asc' } }),
+  }
+}
+
+describe('prisma/seed.ts', () => {
+  it('SCHEMA-08: seeds the required reference data and is safe to re-run', async () => {
+    runSeed()
+    const first = await snapshot()
+
+    expect(first.categories.map((c) => c.name)).toEqual(
+      expect.arrayContaining(['Account and Access', 'Hardware', 'Software', 'Network']),
+    )
+    expect(first.relatedSystems.length).toBeGreaterThanOrEqual(6)
+    expect(first.categories.every((c) => c.isActive)).toBe(true)
+    expect(first.relatedSystems.every((s) => s.isActive)).toBe(true)
+
+    runSeed()
+
+    // Same rows, same ids: upserted by natural key, not re-inserted.
+    expect(await snapshot()).toEqual(first)
+  }, 60_000)
+})


### PR DESCRIPTION
Closes #18.

## What this adds

Prisma models for `Ticket`, `Attachment` and `RelatedSystem`, plus `isActive` on the existing `Category`. Every field comes from `docs/lab-02/specification.md` §7.2 with nothing added.

Migration `20260903055355_add_ticket_attachment_related_system` applies clean on an empty database. I verified that on a throwaway database instead of resetting the dev one.

The seed upserts 7 Related Systems keyed on `name`. Running it twice gives the same rows with the same ids.

## Decisions worth a second opinion

`onDelete` is absent from the spec, so I picked it. `Attachment` cascades when its `Ticket` goes away. The three `Ticket` foreign keys use `Restrict`, so you cannot delete a Category, Related System or Requester that a live Ticket points at. Nothing in Lab 2 deletes anything, so this only matters for data integrity. SCHEMA-06 and SCHEMA-07 pin the behavior down. Say so if you want either flipped.

I left out IT Priority and Ticket Owner. Issue 3 asked for them, but §11-3 of the spec calls their absence a structural decision deferred to Lab 3/4. The spec won.

No storage path column on `Attachment`. §7.2 has only `storedFileName`, and §11-6 pins uploads to a single directory, so the path is that directory plus the stored name.

`RequesterUser` gained one line, `tickets Ticket[]`. Prisma will not validate a relation without a back reference on both sides. Nothing else from Issue 2 changed.

## Seed convergence fix

The Category upsert used `update: {}`, inherited from Lab 1. Deactivating a category by hand and re-running the seed left it deactivated, which contradicts the comment on the RequesterUser loop directly below it. Both reference-table upserts now re-apply `isActive: true`, matching how requesters already behave.

## Gaps I did not close

All of these follow the spec, so none is a deviation. Flagging them because a reviewer will ask.

- `sortBy=summary` and `sortBy=requestedPriority` are allowed by `api-spec.md` §5 but have no index. `ticketNumber` is covered by its unique index.
- `requesterId` is indexed on its own. Every My Tickets query filters by requester and sorts by `createdAt` descending, so `@@index([requesterId, createdAt])` fits that pattern better. Cheap to change now, less so once ticket data exists.
- `summary` and `description` are `TEXT` with no length limit, so BR-20 and BR-21 stay app-level validation.
- Foreign keys prove a row exists but not that `isActive` is true, so `INVALID_REQUESTER` and `INVALID_REFERENCE` remain application checks.

## Tests

Eight new rows in `docs/lab-02/tests.md`, SCHEMA-01 through SCHEMA-08. They cover ticket number uniqueness, status defaults, foreign key integrity, column nullability, index coverage, cascade and restrict behavior, and seed idempotency.

Both test files fail against the schema as it stood before this branch. I confirmed that first, then wrote the migration.

`pnpm --filter server test` passes 13 tests across 5 files, Lab 1 and dev-requester tests included.

One wart: `tests.md` §6 still says implementation has not started, which now contradicts the eight rows marked Pass. I left it alone rather than rewrite a shared document that later issues will also touch.
