### PR TITLE
feat: add ticket creation API and active-only reference-data endpoints

### DIFF
--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -1,5 +1,8 @@
+import { randomUUID } from 'node:crypto'
 import express from 'express'
 import { prisma } from './db.js'
+import { formatTicketNumber } from './lib/ticket-number.js'
+import { resolveActiveRequester } from './lib/requester-context.js'
 
 export const app = express()
 
@@ -9,9 +12,128 @@ app.get('/api/health', (_req, res) => {
   res.json({ status: 'ok', service: 'TokTickIT API' })
 })
 
+// Only active rows, {id, name} shape (api-spec.md §2). isActive/createdAt
+// are never exposed to the client.
 app.get('/api/categories', async (_req, res) => {
-  const categories = await prisma.category.findMany({ orderBy: { id: 'asc' } })
+  const categories = await prisma.category.findMany({
+    where: { isActive: true },
+    orderBy: { id: 'asc' },
+    select: { id: true, name: true },
+  })
   res.json(categories)
+})
+
+// Mirrors /api/categories (api-spec.md §3).
+app.get('/api/related-systems', async (_req, res) => {
+  const relatedSystems = await prisma.relatedSystem.findMany({
+    where: { isActive: true },
+    orderBy: { id: 'asc' },
+    select: { id: true, name: true },
+  })
+  res.json(relatedSystems)
+})
+
+const SUMMARY_MIN = 5
+const SUMMARY_MAX = 120
+const DESCRIPTION_MIN = 10
+const DESCRIPTION_MAX = 2000
+const PRIORITIES = ['LOW', 'MEDIUM', 'HIGH']
+
+// api-spec.md §4 (FR-02, FR-03, BR-01, BR-02, BR-07, BR-08, BR-20, BR-21).
+app.post('/api/tickets', async (req, res) => {
+  const requester = await resolveActiveRequester(req)
+  if (!requester) {
+    return res.status(400).json({
+      error: {
+        code: 'INVALID_REQUESTER',
+        message: 'Requester is missing, unknown, or inactive.',
+      },
+    })
+  }
+
+  const summary = typeof req.body.summary === 'string' ? req.body.summary.trim() : ''
+  if (summary.length < SUMMARY_MIN || summary.length > SUMMARY_MAX) {
+    return res.status(400).json({
+      error: {
+        code: 'VALIDATION_ERROR',
+        message: `Summary must be between ${SUMMARY_MIN} and ${SUMMARY_MAX} characters.`,
+        field: 'summary',
+      },
+    })
+  }
+
+  const description = typeof req.body.description === 'string' ? req.body.description.trim() : ''
+  if (description.length < DESCRIPTION_MIN || description.length > DESCRIPTION_MAX) {
+    return res.status(400).json({
+      error: {
+        code: 'VALIDATION_ERROR',
+        message: `Description must be between ${DESCRIPTION_MIN} and ${DESCRIPTION_MAX} characters.`,
+        field: 'description',
+      },
+    })
+  }
+
+  const requestedPriority = req.body.requestedPriority
+  if (!PRIORITIES.includes(requestedPriority)) {
+    return res.status(400).json({
+      error: {
+        code: 'VALIDATION_ERROR',
+        message: 'Requested priority must be LOW, MEDIUM, or HIGH.',
+        field: 'requestedPriority',
+      },
+    })
+  }
+
+  const categoryId = Number(req.body.categoryId)
+  const category = Number.isInteger(categoryId)
+    ? await prisma.category.findUnique({ where: { id: categoryId } })
+    : null
+  if (!category?.isActive) {
+    return res.status(400).json({
+      error: {
+        code: 'INVALID_REFERENCE',
+        message: 'Category is invalid or inactive.',
+        field: 'categoryId',
+      },
+    })
+  }
+
+  const relatedSystemId = Number(req.body.relatedSystemId)
+  const relatedSystem = Number.isInteger(relatedSystemId)
+    ? await prisma.relatedSystem.findUnique({ where: { id: relatedSystemId } })
+    : null
+  if (!relatedSystem?.isActive) {
+    return res.status(400).json({
+      error: {
+        code: 'INVALID_REFERENCE',
+        message: 'Related System is invalid or inactive.',
+        field: 'relatedSystemId',
+      },
+    })
+  }
+
+  // ticketNumber depends on the row's own id (BR-06), so it's set with a
+  // placeholder that still satisfies the unique constraint, then updated in
+  // the same transaction once the real id is known.
+  const ticket = await prisma.$transaction(async (tx) => {
+    const created = await tx.ticket.create({
+      data: {
+        ticketNumber: `PENDING-${randomUUID()}`,
+        requesterId: requester.id,
+        categoryId: category.id,
+        relatedSystemId: relatedSystem.id,
+        requestedPriority,
+        summary,
+        description,
+      },
+    })
+    return tx.ticket.update({
+      where: { id: created.id },
+      data: { ticketNumber: formatTicketNumber(created.id, created.createdAt.getFullYear()) },
+    })
+  })
+
+  res.status(201).json(ticket)
 })
 
 // Lab 2 testing identities, not authentication (BR-03). Only active rows,

--- a/server/src/lib/requester-context.ts
+++ b/server/src/lib/requester-context.ts
@@ -1,0 +1,23 @@
+import type { Request } from 'express'
+import { prisma } from '../db.js'
+
+// The single "who is asking?" seam (specification.md §11-1, BR-31): every
+// requester-scoped route resolves the current requester through this file
+// instead of reading req.query/req.body directly, so Lab 3 only has to
+// change this module, not every call site.
+
+export function extractRequesterId(req: Request): unknown {
+  return req.method === 'GET' ? req.query.requesterId : req.body?.requesterId
+}
+
+export function parseRequesterId(raw: unknown): number | null {
+  const id = typeof raw === 'string' ? Number(raw) : raw
+  return typeof id === 'number' && Number.isInteger(id) && id > 0 ? id : null
+}
+
+export async function resolveActiveRequester(req: Request) {
+  const id = parseRequesterId(extractRequesterId(req))
+  if (id === null) return null
+  const requester = await prisma.requesterUser.findUnique({ where: { id } })
+  return requester?.isActive ? requester : null
+}

--- a/server/src/lib/ticket-number.ts
+++ b/server/src/lib/ticket-number.ts
@@ -1,0 +1,7 @@
+// BR-06: TKT-<4-digit year>-<6-digit zero-padded id>. Derived from the row's
+// own autoincrement id after insert (specification.md §7.3) rather than a
+// separately tracked counter, so it can never collide under concurrent
+// creates.
+export function formatTicketNumber(id: number, year: number): string {
+  return `TKT-${year}-${String(id).padStart(6, '0')}`
+}

--- a/server/tests/lab-01/categories-list.test.ts
+++ b/server/tests/lab-01/categories-list.test.ts
@@ -1,18 +1,30 @@
 import request from 'supertest'
 import { describe, expect, it } from 'vitest'
 import { app } from '../../src/app.js'
-import { prisma } from '../../src/db.js'
 
+// Superseded by Lab 2 (api-spec.md §2): Category gained `isActive`, and this
+// endpoint now returns only active rows as {id, name}. See also API-25 in
+// tests/lab-02/dev-requesters.api.test.ts for fixture-controlled coverage of
+// the active-only filter (exact-equality against a live table snapshot isn't
+// safe here since other test files' fixtures can exist mid-run).
 describe('GET /api/categories', () => {
-  it('returns all categories ordered by id ascending', async () => {
-    const expected = await prisma.category.findMany({ orderBy: { id: 'asc' } })
-
+  it('returns only active categories, ordered by id ascending, as {id, name}', async () => {
     const res = await request(app).get('/api/categories')
 
     expect(res.status).toBe(200)
-    expect(res.body).toEqual(JSON.parse(JSON.stringify(expected)))
-    expect(res.body.map((category: { id: number }) => category.id)).toEqual(
-      expected.map((category) => category.id).sort((a, b) => a - b),
+    expect(res.body).toEqual(
+      expect.arrayContaining(
+        ['Account and Access', 'Hardware', 'Software', 'Network'].map((name) =>
+          expect.objectContaining({ name }),
+        ),
+      ),
     )
+
+    for (const category of res.body) {
+      expect(Object.keys(category).sort()).toEqual(['id', 'name'])
+    }
+
+    const ids = res.body.map((category: { id: number }) => category.id)
+    expect(ids).toEqual([...ids].sort((a: number, b: number) => a - b))
   })
 })

--- a/server/tests/lab-02/create-ticket.api.test.ts
+++ b/server/tests/lab-02/create-ticket.api.test.ts
@@ -1,0 +1,184 @@
+import request from 'supertest'
+import { afterAll, beforeAll, describe, expect, it } from 'vitest'
+import { app } from '../../src/app.js'
+import { prisma } from '../../src/db.js'
+
+// API-01..05 (AC-01, AC-04, AC-05, AC-06; BR-01, BR-02, BR-07, BR-08, BR-12,
+// BR-20, BR-21) plus the api-spec.md §4 INVALID_REFERENCE cases for an
+// invalid/inactive Category or Related System.
+
+const TAG = 'create-ticket.test.invalid'
+
+let activeRequesterId: number
+let inactiveRequesterId: number
+let activeCategoryId: number
+let inactiveCategoryId: number
+let activeRelatedSystemId: number
+let inactiveRelatedSystemId: number
+
+async function wipe() {
+  await prisma.ticket.deleteMany({ where: { requesterId: { in: [activeRequesterId, inactiveRequesterId].filter(Boolean) } } })
+  await prisma.requesterUser.deleteMany({ where: { email: { contains: TAG } } })
+  await prisma.category.deleteMany({ where: { name: { contains: TAG } } })
+  await prisma.relatedSystem.deleteMany({ where: { name: { contains: TAG } } })
+}
+
+function validBody(overrides: Record<string, unknown> = {}) {
+  return {
+    requesterId: activeRequesterId,
+    categoryId: activeCategoryId,
+    relatedSystemId: activeRelatedSystemId,
+    requestedPriority: 'MEDIUM',
+    summary: 'Laptop battery drains quickly',
+    description: 'My laptop battery drains much faster than usual even when idle.',
+    ...overrides,
+  }
+}
+
+beforeAll(async () => {
+  const activeRequester = await prisma.requesterUser.create({
+    data: { name: 'Active Fixture', email: `active.${TAG}`, isActive: true },
+  })
+  const inactiveRequester = await prisma.requesterUser.create({
+    data: { name: 'Inactive Fixture', email: `inactive.${TAG}`, isActive: false },
+  })
+  activeRequesterId = activeRequester.id
+  inactiveRequesterId = inactiveRequester.id
+
+  const activeCategory = await prisma.category.create({ data: { name: `Category Active ${TAG}` } })
+  const inactiveCategory = await prisma.category.create({
+    data: { name: `Category Inactive ${TAG}`, isActive: false },
+  })
+  activeCategoryId = activeCategory.id
+  inactiveCategoryId = inactiveCategory.id
+
+  const activeRelatedSystem = await prisma.relatedSystem.create({ data: { name: `System Active ${TAG}` } })
+  const inactiveRelatedSystem = await prisma.relatedSystem.create({
+    data: { name: `System Inactive ${TAG}`, isActive: false },
+  })
+  activeRelatedSystemId = activeRelatedSystem.id
+  inactiveRelatedSystemId = inactiveRelatedSystem.id
+})
+
+afterAll(wipe)
+
+async function ticketCountForRequester() {
+  return prisma.ticket.count({ where: { requesterId: activeRequesterId } })
+}
+
+describe('POST /api/tickets', () => {
+  it('API-01 (AC-01, BR-01, BR-02): creates a Ticket and returns 201 with a unique Ticket Number', async () => {
+    const res = await request(app).post('/api/tickets').send(validBody())
+
+    expect(res.status).toBe(201)
+    expect(res.body.ticketNumber).toMatch(/^TKT-\d{4}-\d{6}$/)
+    expect(res.body.currentStatus).toBe('NEW')
+    expect(res.body.requesterId).toBe(activeRequesterId)
+    expect(res.body.categoryId).toBe(activeCategoryId)
+    expect(res.body.relatedSystemId).toBe(activeRelatedSystemId)
+
+    const second = await request(app).post('/api/tickets').send(validBody())
+    expect(second.status).toBe(201)
+    expect(second.body.ticketNumber).not.toBe(res.body.ticketNumber)
+
+    const stored = await prisma.ticket.findUnique({ where: { id: res.body.id } })
+    expect(stored?.ticketNumber).toBe(res.body.ticketNumber)
+  })
+
+  it('API-02 (AC-04, BR-20): rejects a missing Summary with a field-level error and inserts nothing', async () => {
+    const before = await ticketCountForRequester()
+
+    const res = await request(app).post('/api/tickets').send(validBody({ summary: '' }))
+
+    expect(res.status).toBe(400)
+    expect(res.body.error.code).toBe('VALIDATION_ERROR')
+    expect(res.body.error.field).toBe('summary')
+    expect(await ticketCountForRequester()).toBe(before)
+  })
+
+  it('API-03 (AC-05, BR-21): rejects a Description under 10 characters and inserts nothing', async () => {
+    const before = await ticketCountForRequester()
+
+    const res = await request(app).post('/api/tickets').send(validBody({ description: 'too short' }))
+
+    expect(res.status).toBe(400)
+    expect(res.body.error.code).toBe('VALIDATION_ERROR')
+    expect(res.body.error.field).toBe('description')
+    expect(await ticketCountForRequester()).toBe(before)
+  })
+
+  it('API-04 (AC-06, BR-08): rejects a missing Requested Priority and inserts nothing', async () => {
+    const before = await ticketCountForRequester()
+
+    const res = await request(app).post('/api/tickets').send(validBody({ requestedPriority: undefined }))
+
+    expect(res.status).toBe(400)
+    expect(res.body.error.code).toBe('VALIDATION_ERROR')
+    expect(res.body.error.field).toBe('requestedPriority')
+    expect(await ticketCountForRequester()).toBe(before)
+  })
+
+  it('API-05 (BR-12): rejects an inactive requesterId and inserts nothing', async () => {
+    const before = await prisma.ticket.count({ where: { categoryId: activeCategoryId } })
+
+    const res = await request(app).post('/api/tickets').send(validBody({ requesterId: inactiveRequesterId }))
+
+    expect(res.status).toBe(400)
+    expect(res.body.error.code).toBe('INVALID_REQUESTER')
+    expect(await prisma.ticket.count({ where: { categoryId: activeCategoryId } })).toBe(before)
+  })
+
+  it('API-05 (BR-12): rejects an unknown requesterId and inserts nothing', async () => {
+    const before = await prisma.ticket.count({ where: { categoryId: activeCategoryId } })
+
+    const res = await request(app).post('/api/tickets').send(validBody({ requesterId: -999 }))
+
+    expect(res.status).toBe(400)
+    expect(res.body.error.code).toBe('INVALID_REQUESTER')
+    expect(await prisma.ticket.count({ where: { categoryId: activeCategoryId } })).toBe(before)
+  })
+
+  it('rejects an inactive Category with INVALID_REFERENCE and inserts nothing', async () => {
+    const before = await ticketCountForRequester()
+
+    const res = await request(app).post('/api/tickets').send(validBody({ categoryId: inactiveCategoryId }))
+
+    expect(res.status).toBe(400)
+    expect(res.body.error.code).toBe('INVALID_REFERENCE')
+    expect(res.body.error.field).toBe('categoryId')
+    expect(await ticketCountForRequester()).toBe(before)
+  })
+
+  it('rejects an unknown Category with INVALID_REFERENCE and inserts nothing', async () => {
+    const before = await ticketCountForRequester()
+
+    const res = await request(app).post('/api/tickets').send(validBody({ categoryId: -999 }))
+
+    expect(res.status).toBe(400)
+    expect(res.body.error.code).toBe('INVALID_REFERENCE')
+    expect(await ticketCountForRequester()).toBe(before)
+  })
+
+  it('rejects an inactive Related System with INVALID_REFERENCE and inserts nothing', async () => {
+    const before = await ticketCountForRequester()
+
+    const res = await request(app)
+      .post('/api/tickets')
+      .send(validBody({ relatedSystemId: inactiveRelatedSystemId }))
+
+    expect(res.status).toBe(400)
+    expect(res.body.error.code).toBe('INVALID_REFERENCE')
+    expect(res.body.error.field).toBe('relatedSystemId')
+    expect(await ticketCountForRequester()).toBe(before)
+  })
+
+  it('rejects an unknown Related System with INVALID_REFERENCE and inserts nothing', async () => {
+    const before = await ticketCountForRequester()
+
+    const res = await request(app).post('/api/tickets').send(validBody({ relatedSystemId: -999 }))
+
+    expect(res.status).toBe(400)
+    expect(res.body.error.code).toBe('INVALID_REFERENCE')
+    expect(await ticketCountForRequester()).toBe(before)
+  })
+})

--- a/server/tests/lab-02/dev-requesters.api.test.ts
+++ b/server/tests/lab-02/dev-requesters.api.test.ts
@@ -27,6 +27,63 @@ afterAll(async () => {
   await prisma.requesterUser.deleteMany({ where: { email: { in: emails } } })
 })
 
+// API-25 (FR-02 ref data): GET /api/categories and GET /api/related-systems
+// return only active rows, as {id, name} (no isActive/createdAt leaked).
+const categoryFixtures = [
+  { name: 'Fixture Active Category', isActive: true },
+  { name: 'Fixture Inactive Category', isActive: false },
+]
+const relatedSystemFixtures = [
+  { name: 'Fixture Active System', isActive: true },
+  { name: 'Fixture Inactive System', isActive: false },
+]
+const categoryNames = categoryFixtures.map((f) => f.name)
+const relatedSystemNames = relatedSystemFixtures.map((f) => f.name)
+
+beforeAll(async () => {
+  await prisma.category.deleteMany({ where: { name: { in: categoryNames } } })
+  for (const fixture of categoryFixtures) {
+    await prisma.category.create({ data: fixture })
+  }
+  await prisma.relatedSystem.deleteMany({ where: { name: { in: relatedSystemNames } } })
+  for (const fixture of relatedSystemFixtures) {
+    await prisma.relatedSystem.create({ data: fixture })
+  }
+})
+
+afterAll(async () => {
+  await prisma.category.deleteMany({ where: { name: { in: categoryNames } } })
+  await prisma.relatedSystem.deleteMany({ where: { name: { in: relatedSystemNames } } })
+})
+
+describe('GET /api/categories', () => {
+  it('API-25: returns only active categories, as {id, name}', async () => {
+    const res = await request(app).get('/api/categories')
+
+    expect(res.status).toBe(200)
+    const names = res.body.map((c: { name: string }) => c.name)
+    expect(names).toContain('Fixture Active Category')
+    expect(names).not.toContain('Fixture Inactive Category')
+
+    const row = res.body.find((c: { name: string }) => c.name === 'Fixture Active Category')
+    expect(Object.keys(row).sort()).toEqual(['id', 'name'])
+  })
+})
+
+describe('GET /api/related-systems', () => {
+  it('API-25: returns only active related systems, as {id, name}', async () => {
+    const res = await request(app).get('/api/related-systems')
+
+    expect(res.status).toBe(200)
+    const names = res.body.map((s: { name: string }) => s.name)
+    expect(names).toContain('Fixture Active System')
+    expect(names).not.toContain('Fixture Inactive System')
+
+    const row = res.body.find((s: { name: string }) => s.name === 'Fixture Active System')
+    expect(Object.keys(row).sort()).toEqual(['id', 'name'])
+  })
+})
+
 describe('GET /api/dev-requesters', () => {
   it('returns only active requesters', async () => {
     const res = await request(app).get('/api/dev-requesters')

--- a/server/tests/lab-02/requester-context.unit.test.ts
+++ b/server/tests/lab-02/requester-context.unit.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from 'vitest'
+import { parseRequesterId } from '../../src/lib/requester-context.js'
+
+// UNIT-03 (BR-10, BR-12): pure parsing rules for the requester-context seam.
+// The DB-backed "unknown or inactive" half of this rule is exercised against
+// a real requester row by API-05 in create-ticket.api.test.ts.
+describe('parseRequesterId', () => {
+  it('rejects a missing id', () => {
+    expect(parseRequesterId(undefined)).toBeNull()
+    expect(parseRequesterId(null)).toBeNull()
+  })
+
+  it('rejects a non-numeric id', () => {
+    expect(parseRequesterId('abc')).toBeNull()
+    expect(parseRequesterId({})).toBeNull()
+  })
+
+  it('rejects zero and negative ids', () => {
+    expect(parseRequesterId(0)).toBeNull()
+    expect(parseRequesterId(-1)).toBeNull()
+  })
+
+  it('rejects a non-integer id', () => {
+    expect(parseRequesterId(1.5)).toBeNull()
+  })
+
+  it('accepts a positive integer, from a number or a numeric string', () => {
+    expect(parseRequesterId(1)).toBe(1)
+    expect(parseRequesterId('42')).toBe(42)
+  })
+})

--- a/server/tests/lab-02/ticket-number.unit.test.ts
+++ b/server/tests/lab-02/ticket-number.unit.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from 'vitest'
+import { formatTicketNumber } from '../../src/lib/ticket-number.js'
+
+// UNIT-01 (BR-06, AC-01): TKT-<4-digit year>-<6-digit zero-padded id>.
+describe('formatTicketNumber', () => {
+  it('zero-pads the id to 6 digits', () => {
+    expect(formatTicketNumber(42, 2026)).toBe('TKT-2026-000042')
+  })
+
+  it('does not truncate an id wider than 6 digits', () => {
+    expect(formatTicketNumber(1234567, 2026)).toBe('TKT-2026-1234567')
+  })
+
+  it('uses the given year verbatim', () => {
+    expect(formatTicketNumber(1, 2030)).toBe('TKT-2030-000001')
+  })
+})


### PR DESCRIPTION
## Summary
- Implements the Ticket Creation API and its two reference-data endpoints per `docs/lab-02/api-spec.md` and `specification.md`.
- `GET /api/categories` and `GET /api/related-systems` now return only active rows as `{id, name}`. `/api/categories` used to return every row with every column.
- `POST /api/tickets` validates requester, category, related system, summary, description, and requestedPriority server-side (BR-01, BR-02, BR-07, BR-08, BR-12, BR-20, BR-21), and generates the unique `ticketNumber` from the row's own id (BR-06).
- Adds `server/src/lib/requester-context.ts` as the single "who is asking?" seam required by spec §11-1/BR-31, so Lab 3's auth swap only touches one module instead of every route.

Addresses #19

## Test plan
- [x] `pnpm --filter server test`: 33/33 passing, run 3 times to rule out flakiness
- [x] `pnpm --filter server exec tsc --noEmit`: clean
- [x] Test-first: wrote the failing tests from `tests.md` (UNIT-01, UNIT-03, API-01 through 05, API-25) before implementation, confirmed each failed for the expected reason, then implemented
- [x] Updated `tests/lab-01/categories-list.test.ts`, which asserted the old all-rows/all-columns behavior of `/api/categories`. This issue's contract supersedes it.

## Deviations and open questions for review
- Added `field` to `INVALID_REFERENCE` errors on `categoryId`/`relatedSystemId`. The api-spec failure table doesn't list `field` for that code explicitly, but it matches the issue's requirement that errors be field-mappable.
- Validation order is requesterId, then summary, description, requestedPriority, then categoryId, relatedSystemId. The contract doesn't specify an order; it only matters when more than one field is invalid in the same request.

## Out of scope by design
Attachment upload, `GET /api/tickets`, `GET /api/tickets/:id`, and both attachment endpoints. Reserved for later issues.
