### PR TITLE
Add My Tickets screen and ticket-list API

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -2,6 +2,7 @@ import { BrowserRouter, Navigate, Outlet, Route, Routes } from 'react-router-dom
 import AppShell from './AppShell'
 import CreateTicket from './CreateTicket'
 import DevRequesterSelection from './DevRequesterSelection'
+import MyTickets from './MyTickets'
 import { RequesterProvider, useRequester } from './RequesterContext'
 import SystemCheck from './SystemCheck'
 
@@ -41,7 +42,7 @@ export function AppRoutes() {
       <Route path="/system-check" element={<SystemCheck />} />
 
       <Route element={<RequireRequester />}>
-        <Route path="/tickets" element={<ComingSoon title="My Tickets" />} />
+        <Route path="/tickets" element={<MyTickets />} />
         <Route path="/tickets/new" element={<CreateTicket />} />
         <Route path="/tickets/:id" element={<ComingSoon title="Ticket Detail" />} />
       </Route>

--- a/client/src/MyTickets.tsx
+++ b/client/src/MyTickets.tsx
@@ -1,0 +1,385 @@
+import { useCallback, useEffect, useState } from 'react'
+import { Link, useNavigate } from 'react-router-dom'
+import { fetchCategories, fetchTickets } from './apiClient'
+import { useRequester } from './RequesterContext'
+import type { Category, SortDirection, TicketListResponse, TicketSortField, TicketStatus } from './types'
+
+type LoadState = 'loading' | 'ready' | 'error'
+
+const PAGE_SIZE = 10
+const SEARCH_DEBOUNCE_MS = 300
+
+const STATUS_OPTIONS: TicketStatus[] = ['NEW', 'OPEN', 'IN_PROGRESS', 'PENDING', 'RESOLVED', 'CLOSED', 'CANCELLED']
+
+const STATUS_LABEL: Record<TicketStatus, string> = {
+  NEW: 'New',
+  OPEN: 'Open',
+  IN_PROGRESS: 'In Progress',
+  PENDING: 'Pending',
+  RESOLVED: 'Resolved',
+  CLOSED: 'Closed',
+  CANCELLED: 'Cancelled',
+}
+
+// ui-spec.md §9: Pending/In Progress and Cancelled/Closed share a badge
+// colour, so each pair also carries a distinct icon (never colour alone).
+const STATUS_ICON: Partial<Record<TicketStatus, string>> = {
+  PENDING: 'bi-hourglass-split',
+  IN_PROGRESS: 'bi-arrow-repeat',
+  CANCELLED: 'bi-x-circle',
+  CLOSED: 'bi-check2-circle',
+}
+
+const STATUS_BADGE_CLASS: Record<TicketStatus, string> = {
+  NEW: 'zg-badge-status-new',
+  OPEN: 'zg-badge-status-open',
+  IN_PROGRESS: 'zg-badge-status-in-progress',
+  PENDING: 'zg-badge-status-pending',
+  RESOLVED: 'zg-badge-status-resolved',
+  CLOSED: 'zg-badge-status-closed',
+  CANCELLED: 'zg-badge-status-cancelled',
+}
+
+const PRIORITY_BADGE_CLASS = {
+  LOW: 'zg-badge-priority-low',
+  MEDIUM: 'zg-badge-priority-medium',
+  HIGH: 'zg-badge-priority-high',
+} as const
+
+// ui-spec.md §11.3: only these columns are sortable (BR-18); Category and
+// Last Updated are display-only.
+const SORTABLE_COLUMNS: { field: TicketSortField; label: string }[] = [
+  { field: 'ticketNumber', label: 'Ticket No.' },
+  { field: 'createdAt', label: 'Created Date' },
+  { field: 'summary', label: 'Summary' },
+  { field: 'requestedPriority', label: 'Requested Priority' },
+  { field: 'currentStatus', label: 'Current Status' },
+]
+
+function StatusBadge({ status }: { status: TicketStatus }) {
+  const icon = STATUS_ICON[status]
+  return (
+    <span className={`zg-badge ${STATUS_BADGE_CLASS[status]}`}>
+      {icon && <i className={`bi ${icon}`} aria-hidden="true" />}
+      {STATUS_LABEL[status]}
+    </span>
+  )
+}
+
+function PriorityBadge({ priority }: { priority: keyof typeof PRIORITY_BADGE_CLASS }) {
+  const label = priority.charAt(0) + priority.slice(1).toLowerCase()
+  return <span className={`zg-badge ${PRIORITY_BADGE_CLASS[priority]}`}>{label}</span>
+}
+
+function formatDate(iso: string): string {
+  return new Date(iso).toLocaleDateString()
+}
+
+function MyTickets() {
+  const { requester } = useRequester()
+  const navigate = useNavigate()
+
+  const [state, setState] = useState<LoadState>('loading')
+  const [response, setResponse] = useState<TicketListResponse | null>(null)
+  const [categories, setCategories] = useState<Category[]>([])
+
+  const [searchInput, setSearchInput] = useState('')
+  const [search, setSearch] = useState('')
+  const [categoryId, setCategoryId] = useState('')
+  const [requestedPriority, setRequestedPriority] = useState('')
+  const [status, setStatus] = useState('')
+  const [sortBy, setSortBy] = useState<TicketSortField>('createdAt')
+  const [sortDir, setSortDir] = useState<SortDirection>('desc')
+  const [page, setPage] = useState(1)
+
+  useEffect(() => {
+    fetchCategories().then(setCategories).catch(() => setCategories([]))
+  }, [])
+
+  // AC-16: the list narrows as the Requester types, without a request per keystroke.
+  useEffect(() => {
+    const timer = setTimeout(() => setSearch(searchInput.trim()), SEARCH_DEBOUNCE_MS)
+    return () => clearTimeout(timer)
+  }, [searchInput])
+
+  useEffect(() => {
+    setPage(1)
+  }, [search, categoryId, requestedPriority, status])
+
+  const load = useCallback(() => {
+    if (!requester) return
+    setState('loading')
+    fetchTickets(requester.id, {
+      search: search || undefined,
+      categoryId: categoryId ? Number(categoryId) : undefined,
+      requestedPriority: (requestedPriority || undefined) as never,
+      status: (status || undefined) as never,
+      sortBy,
+      sortDir,
+      page,
+      pageSize: PAGE_SIZE,
+    })
+      .then((data) => {
+        setResponse(data)
+        setState('ready')
+      })
+      .catch(() => setState('error'))
+  }, [requester, search, categoryId, requestedPriority, status, sortBy, sortDir, page])
+
+  useEffect(load, [load])
+
+  const toggleSort = (field: TicketSortField) => {
+    if (field === sortBy) {
+      setSortDir((dir) => (dir === 'asc' ? 'desc' : 'asc'))
+    } else {
+      setSortBy(field)
+      setSortDir('asc')
+    }
+  }
+
+  const clearFilters = () => {
+    setSearchInput('')
+    setSearch('')
+    setCategoryId('')
+    setRequestedPriority('')
+    setStatus('')
+    setPage(1)
+  }
+
+  const openTicket = (id: number) => navigate(`/tickets/${id}`)
+
+  const isEmptyAccount = state === 'ready' && response?.hasAnyTickets === false
+  const isNoResults = state === 'ready' && response !== null && response.hasAnyTickets && response.totalCount === 0
+  const hasRows = state === 'ready' && response !== null && response.data.length > 0
+
+  const rangeStart = response && response.totalCount > 0 ? (response.page - 1) * response.pageSize + 1 : 0
+  const rangeEnd = response ? Math.min(response.page * response.pageSize, response.totalCount) : 0
+
+  return (
+    <div>
+      <div className="zg-actions">
+        <div>
+          <h1 className="zg-title">My Tickets</h1>
+          <p className="zg-helper">Search, filter, and open the Tickets you've submitted.</p>
+        </div>
+        {!isEmptyAccount && (
+          <div className="zg-actions" style={{ justifyContent: 'flex-end' }}>
+            {!isNoResults && (
+              <button type="button" className="zg-btn zg-btn-tertiary" onClick={clearFilters}>
+                Clear Filters
+              </button>
+            )}
+            <Link to="/tickets/new" className="zg-btn zg-btn-primary zg-btn-sm">
+              <i className="bi bi-plus-lg" aria-hidden="true" />
+              Create Ticket
+            </Link>
+          </div>
+        )}
+      </div>
+
+      {!isEmptyAccount && (
+        <div className="zg-filter-row" style={{ marginTop: 'var(--zg-space-4)' }}>
+          <div className="zg-filter-field">
+            <label className="zg-label" htmlFor="my-tickets-search">
+              Search
+            </label>
+            <input
+              id="my-tickets-search"
+              className="zg-field"
+              type="text"
+              placeholder="Search by ticket number or summary…"
+              value={searchInput}
+              onChange={(e) => setSearchInput(e.target.value)}
+            />
+          </div>
+          <div className="zg-filter-field">
+            <label className="zg-label" htmlFor="my-tickets-category">
+              Category
+            </label>
+            <select
+              id="my-tickets-category"
+              className="zg-field"
+              value={categoryId}
+              onChange={(e) => setCategoryId(e.target.value)}
+            >
+              <option value="">All Categories</option>
+              {categories.map((c) => (
+                <option key={c.id} value={c.id}>
+                  {c.name}
+                </option>
+              ))}
+            </select>
+          </div>
+          <div className="zg-filter-field">
+            <label className="zg-label" htmlFor="my-tickets-priority">
+              Requested Priority
+            </label>
+            <select
+              id="my-tickets-priority"
+              className="zg-field"
+              value={requestedPriority}
+              onChange={(e) => setRequestedPriority(e.target.value)}
+            >
+              <option value="">All Priorities</option>
+              <option value="LOW">Low</option>
+              <option value="MEDIUM">Medium</option>
+              <option value="HIGH">High</option>
+            </select>
+          </div>
+          <div className="zg-filter-field">
+            <label className="zg-label" htmlFor="my-tickets-status">
+              Current Status
+            </label>
+            <select
+              id="my-tickets-status"
+              className="zg-field"
+              value={status}
+              onChange={(e) => setStatus(e.target.value)}
+            >
+              <option value="">All Statuses</option>
+              {STATUS_OPTIONS.map((s) => (
+                <option key={s} value={s}>
+                  {STATUS_LABEL[s]}
+                </option>
+              ))}
+            </select>
+          </div>
+        </div>
+      )}
+
+      {state === 'loading' && !response && (
+        <p className="zg-skeleton" aria-live="polite" style={{ marginTop: 'var(--zg-space-4)' }}>
+          Loading your tickets…
+        </p>
+      )}
+
+      {state === 'error' && (
+        <div style={{ marginTop: 'var(--zg-space-4)' }}>
+          <p className="zg-error" role="alert">
+            Unable to load your tickets. Please try again.
+          </p>
+          <button type="button" className="zg-btn zg-btn-secondary" onClick={load}>
+            Retry
+          </button>
+        </div>
+      )}
+
+      {isEmptyAccount && (
+        <div className="zg-callout" style={{ marginTop: 'var(--zg-space-5)', textAlign: 'center' }}>
+          <i className="bi bi-inbox" aria-hidden="true" style={{ fontSize: '32px' }} />
+          <p className="zg-title" style={{ fontSize: '18px', marginTop: 'var(--zg-space-3)' }}>
+            You haven't created any tickets yet
+          </p>
+          <Link to="/tickets/new" className="zg-btn zg-btn-primary" style={{ marginTop: 'var(--zg-space-3)' }}>
+            <i className="bi bi-plus-lg" aria-hidden="true" />
+            Create Your First Ticket
+          </Link>
+        </div>
+      )}
+
+      {isNoResults && (
+        <div className="zg-callout" style={{ marginTop: 'var(--zg-space-5)', textAlign: 'center' }}>
+          <p className="zg-title" style={{ fontSize: '18px' }}>
+            No tickets match your filters
+          </p>
+          <button
+            type="button"
+            className="zg-btn zg-btn-secondary"
+            style={{ marginTop: 'var(--zg-space-3)' }}
+            onClick={clearFilters}
+          >
+            Clear Filters
+          </button>
+        </div>
+      )}
+
+      {hasRows && response && (
+        <>
+          <div className="zg-table-wrap" data-testid="tickets-table" style={{ marginTop: 'var(--zg-space-4)' }}>
+            <table className="zg-table">
+              <thead>
+                <tr>
+                  {SORTABLE_COLUMNS.map(({ field, label }) => (
+                    <th key={field}>
+                      <button type="button" className="zg-sort-btn" onClick={() => toggleSort(field)}>
+                        {label}
+                        {sortBy === field && (
+                          <i className={`bi ${sortDir === 'asc' ? 'bi-caret-up-fill' : 'bi-caret-down-fill'}`} aria-hidden="true" />
+                        )}
+                      </button>
+                    </th>
+                  ))}
+                  <th>Category</th>
+                  <th>Last Updated</th>
+                </tr>
+              </thead>
+              <tbody>
+                {response.data.map((t) => (
+                  <tr key={t.id} onClick={() => openTicket(t.id)}>
+                    <td>
+                      <Link to={`/tickets/${t.id}`} onClick={(e) => e.stopPropagation()}>
+                        {t.ticketNumber}
+                      </Link>
+                    </td>
+                    <td>{formatDate(t.createdAt)}</td>
+                    <td>{t.summary}</td>
+                    <td>
+                      <PriorityBadge priority={t.requestedPriority} />
+                    </td>
+                    <td>
+                      <StatusBadge status={t.currentStatus} />
+                    </td>
+                    <td>{t.categoryName}</td>
+                    <td>{formatDate(t.updatedAt)}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+
+          <div className="zg-ticket-cards" data-testid="tickets-cards" style={{ marginTop: 'var(--zg-space-4)' }}>
+            {response.data.map((t) => (
+              <Link key={t.id} to={`/tickets/${t.id}`} className="zg-ticket-card">
+                <div className="zg-ticket-card-header">
+                  <strong>{t.ticketNumber}</strong>
+                </div>
+                <p style={{ margin: 'var(--zg-space-1) 0' }}>{t.summary}</p>
+                <div className="zg-actions">
+                  <PriorityBadge priority={t.requestedPriority} />
+                  <StatusBadge status={t.currentStatus} />
+                </div>
+                <p className="zg-helper" style={{ marginTop: 'var(--zg-space-2)' }}>
+                  Created {formatDate(t.createdAt)} · Updated {formatDate(t.updatedAt)}
+                </p>
+              </Link>
+            ))}
+          </div>
+
+          <div className="zg-pagination">
+            <button
+              type="button"
+              className="zg-btn zg-btn-secondary"
+              disabled={response.page <= 1}
+              onClick={() => setPage((p) => p - 1)}
+            >
+              Previous
+            </button>
+            <span className="zg-helper">
+              Showing {rangeStart} to {rangeEnd} of {response.totalCount} tickets
+            </span>
+            <button
+              type="button"
+              className="zg-btn zg-btn-secondary"
+              disabled={response.page >= response.totalPages}
+              onClick={() => setPage((p) => p + 1)}
+            >
+              Next
+            </button>
+          </div>
+        </>
+      )}
+    </div>
+  )
+}
+
+export default MyTickets

--- a/client/src/apiClient.ts
+++ b/client/src/apiClient.ts
@@ -1,4 +1,14 @@
-import type { Attachment, Category, RelatedSystem, RequestedPriority, Ticket } from './types'
+import type {
+  Attachment,
+  Category,
+  RelatedSystem,
+  RequestedPriority,
+  SortDirection,
+  Ticket,
+  TicketListResponse,
+  TicketSortField,
+  TicketStatus,
+} from './types'
 
 /** specification.md §11-1 (BR-31): the single frontend seam that attaches the
  *  current Requester's id to a request. Lab 3 only has to change this file
@@ -42,6 +52,32 @@ export function createTicket(requesterId: number, input: CreateTicketInput): Pro
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({ requesterId, ...input }),
   }).then((res) => parseJsonOrThrow<Ticket>(res))
+}
+
+export type TicketListParams = {
+  search?: string
+  categoryId?: number
+  requestedPriority?: RequestedPriority
+  status?: TicketStatus
+  sortBy?: TicketSortField
+  sortDir?: SortDirection
+  page?: number
+  pageSize?: number
+}
+
+// api-spec.md §5: requesterId is the only required param; everything else is
+// omitted from the query string when unset rather than sent as an empty value.
+export function fetchTickets(requesterId: number, params: TicketListParams = {}): Promise<TicketListResponse> {
+  const query = new URLSearchParams({ requesterId: String(requesterId) })
+  if (params.search) query.set('search', params.search)
+  if (params.categoryId !== undefined) query.set('categoryId', String(params.categoryId))
+  if (params.requestedPriority) query.set('requestedPriority', params.requestedPriority)
+  if (params.status) query.set('status', params.status)
+  if (params.sortBy) query.set('sortBy', params.sortBy)
+  if (params.sortDir) query.set('sortDir', params.sortDir)
+  if (params.page) query.set('page', String(params.page))
+  if (params.pageSize) query.set('pageSize', String(params.pageSize))
+  return fetch(`/api/tickets?${query.toString()}`).then((res) => parseJsonOrThrow<TicketListResponse>(res))
 }
 
 export function uploadAttachment(requesterId: number, ticketId: number, file: File): Promise<Attachment> {

--- a/client/src/types.ts
+++ b/client/src/types.ts
@@ -26,6 +26,30 @@ export type Ticket = {
   updatedAt: string
 }
 
+export type TicketListItem = {
+  id: number
+  ticketNumber: string
+  summary: string
+  categoryId: number
+  categoryName: string
+  requestedPriority: RequestedPriority
+  currentStatus: TicketStatus
+  createdAt: string
+  updatedAt: string
+}
+
+export type TicketSortField = 'createdAt' | 'ticketNumber' | 'summary' | 'requestedPriority' | 'currentStatus'
+export type SortDirection = 'asc' | 'desc'
+
+export type TicketListResponse = {
+  data: TicketListItem[]
+  page: number
+  pageSize: number
+  totalCount: number
+  totalPages: number
+  hasAnyTickets: boolean
+}
+
 export type Attachment = {
   id: number
   ticketId: number

--- a/client/src/zen-green.css
+++ b/client/src/zen-green.css
@@ -112,13 +112,18 @@ body {
 
 /* Buttons — ui-spec §4. Every button keeps visible text. */
 .zg-btn {
+  align-items: center;
   border-radius: 6px;
   border: 1px solid transparent;
   cursor: pointer;
+  display: inline-flex;
   font-size: 14px;
   font-weight: 500;
+  gap: var(--zg-space-2);
+  justify-content: center;
   min-height: 44px; /* touch target at mobile widths — ui-spec §8 */
   padding: var(--zg-space-2) var(--zg-space-5);
+  text-decoration: none; /* a Link styled as a button is not a plain anchor */
 }
 
 .zg-btn-primary {
@@ -149,6 +154,23 @@ body {
 .zg-btn[aria-disabled='true'] {
   cursor: not-allowed;
   opacity: 0.55;
+}
+
+/* Compact variant for toolbar/header actions (e.g. My Tickets' top-right
+   Create Ticket) — the full 44px tap target only matters at mobile widths
+   (ui-spec §8), so it's restored there and nowhere else. */
+.zg-btn-sm {
+  font-size: 13px;
+  min-height: 36px;
+  padding: var(--zg-space-1) var(--zg-space-4);
+}
+
+@media (max-width: 767px) {
+  .zg-btn-sm {
+    font-size: 14px;
+    min-height: 44px;
+    padding: var(--zg-space-2) var(--zg-space-5);
+  }
 }
 
 /* Application shell — ui-spec §10. */
@@ -293,6 +315,166 @@ textarea.zg-field {
   .zg-grid-3 {
     grid-template-columns: 1fr;
   }
+}
+
+/* My Tickets — ui-spec.md §11.3. */
+.zg-filter-row {
+  align-items: flex-end;
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--zg-space-3);
+}
+
+.zg-filter-field {
+  display: flex;
+  flex: 1 1 160px;
+  flex-direction: column;
+  min-width: 160px;
+}
+
+/* Badges — ui-spec §9. Colour is reinforcement only; label text (and an
+   icon for the two same-colour pairs) is always present alongside it. */
+.zg-badge {
+  align-items: center;
+  border-radius: 999px;
+  display: inline-flex;
+  font-size: 13px;
+  font-weight: 500;
+  gap: var(--zg-space-1);
+  padding: 2px var(--zg-space-3);
+  white-space: nowrap;
+}
+
+.zg-badge-priority-low {
+  background: var(--zg-pale);
+  color: var(--zg-secondary);
+}
+
+.zg-badge-priority-medium {
+  background: var(--zg-warning-bg);
+  color: var(--zg-warning-text);
+}
+
+.zg-badge-priority-high {
+  background: #fbe7e5;
+  color: var(--zg-error-text);
+}
+
+.zg-badge-status-new {
+  background: #e7eef5;
+  color: #33475b;
+}
+
+.zg-badge-status-open {
+  background: #dcebfb;
+  color: #1b5fa8;
+}
+
+.zg-badge-status-in-progress {
+  background: var(--zg-warning-bg);
+  color: var(--zg-warning-text);
+}
+
+.zg-badge-status-pending {
+  background: var(--zg-warning-bg);
+  color: var(--zg-warning-text);
+}
+
+.zg-badge-status-resolved {
+  background: var(--zg-pale);
+  color: var(--zg-secondary);
+}
+
+.zg-badge-status-closed {
+  background: #eaeaea;
+  color: #5a5a5a;
+}
+
+.zg-badge-status-cancelled {
+  background: #eaeaea;
+  color: #5a5a5a;
+}
+
+/* Desktop/tablet table (ui-spec §11.3, §8). */
+.zg-table-wrap {
+  display: block;
+  overflow-x: auto;
+}
+
+.zg-table {
+  border-collapse: collapse;
+  width: 100%;
+}
+
+.zg-table th,
+.zg-table td {
+  border-bottom: 1px solid var(--zg-field-readonly-border);
+  padding: var(--zg-space-3);
+  text-align: left;
+}
+
+.zg-table th {
+  font-weight: 600;
+}
+
+.zg-table tbody tr {
+  cursor: pointer;
+}
+
+.zg-table tbody tr:hover {
+  background: var(--zg-pale);
+}
+
+.zg-sort-btn {
+  align-items: center;
+  background: none;
+  border: none;
+  color: inherit;
+  cursor: pointer;
+  display: inline-flex;
+  font: inherit;
+  gap: var(--zg-space-1);
+  padding: 0;
+}
+
+/* Mobile card list, hidden on desktop/tablet — the table/card swap is CSS-
+   only, never a horizontal scroll substitute (ui-spec §8, §11.3). */
+.zg-ticket-cards {
+  display: none;
+}
+
+.zg-ticket-card {
+  background: var(--zg-surface);
+  border: 1px solid var(--zg-field-readonly-border);
+  border-radius: 8px;
+  color: inherit;
+  display: block;
+  margin-bottom: var(--zg-space-3);
+  padding: var(--zg-space-4);
+  text-decoration: none;
+}
+
+.zg-ticket-card:hover {
+  border-color: var(--zg-secondary);
+}
+
+@media (max-width: 767px) {
+  .zg-table-wrap {
+    display: none;
+  }
+
+  .zg-ticket-cards {
+    display: block;
+  }
+}
+
+.zg-pagination {
+  align-items: center;
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--zg-space-3);
+  justify-content: center;
+  margin-top: var(--zg-space-4);
 }
 
 .zg-success-banner {

--- a/client/tests/lab-02/DevRequesterSelection.test.tsx
+++ b/client/tests/lab-02/DevRequesterSelection.test.tsx
@@ -16,10 +16,27 @@ const inactiveRequester = {
   email: 'patricia.reyes@example.com',
 }
 
+// Other tests in this file only exercise the Selection screen and the app
+// shell, but Continue navigates into My Tickets, which fetches its own
+// data — give those calls a harmless empty response so they don't crash.
 function mockRequesters(body: unknown, status = 200) {
   vi.stubGlobal(
     'fetch',
-    vi.fn(() => Promise.resolve(new Response(JSON.stringify(body), { status }))),
+    vi.fn((url: string) => {
+      if (url === '/api/dev-requesters') return Promise.resolve(new Response(JSON.stringify(body), { status }))
+      if (url === '/api/categories' || url === '/api/related-systems') {
+        return Promise.resolve(new Response(JSON.stringify([]), { status: 200 }))
+      }
+      if (url.startsWith('/api/tickets?')) {
+        return Promise.resolve(
+          new Response(
+            JSON.stringify({ data: [], page: 1, pageSize: 10, totalCount: 0, totalPages: 0, hasAnyTickets: false }),
+            { status: 200 },
+          ),
+        )
+      }
+      return Promise.reject(new Error(`unexpected fetch: ${url}`))
+    }),
   )
 }
 

--- a/client/tests/lab-02/MyTickets.test.tsx
+++ b/client/tests/lab-02/MyTickets.test.tsx
@@ -1,0 +1,164 @@
+import { cleanup, render, screen, waitFor, within } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { MemoryRouter } from 'react-router-dom'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { AppRoutes } from '../../src/App'
+import { REQUESTER_STORAGE_KEY, RequesterProvider } from '../../src/RequesterContext'
+import type { TicketListItem, TicketListResponse } from '../../src/types'
+
+// UI-10..13 (AC-16, AC-18, AC-19, AC-20; BR-30).
+
+const requester = { id: 7, name: 'Priya Shah', email: 'priya.shah@example.com' }
+
+function jsonResponse(body: unknown, status = 200) {
+  return Promise.resolve(new Response(JSON.stringify(body), { status }))
+}
+
+function ticket(overrides: Partial<TicketListItem> = {}): TicketListItem {
+  return {
+    id: 1,
+    ticketNumber: 'TKT-2026-000001',
+    summary: 'Laptop battery drains quickly',
+    categoryId: 1,
+    categoryName: 'Hardware',
+    requestedPriority: 'MEDIUM',
+    currentStatus: 'NEW',
+    createdAt: '2026-01-01T09:00:00.000Z',
+    updatedAt: '2026-01-01T09:00:00.000Z',
+    ...overrides,
+  }
+}
+
+function mockApi(ticketsHandler: (url: URL) => TicketListResponse) {
+  const fetchMock = vi.fn((url: string) => {
+    if (url === '/api/categories') return jsonResponse([{ id: 1, name: 'Hardware' }, { id: 2, name: 'Software' }])
+    if (url === '/api/related-systems') return jsonResponse([{ id: 5, name: 'Corporate Laptop' }])
+    if (url.startsWith('/api/tickets?')) {
+      return jsonResponse(ticketsHandler(new URL(url, 'http://localhost')))
+    }
+    return Promise.reject(new Error(`unexpected fetch: ${url}`))
+  })
+  vi.stubGlobal('fetch', fetchMock)
+  return fetchMock
+}
+
+function renderMyTickets() {
+  localStorage.setItem(REQUESTER_STORAGE_KEY, JSON.stringify(requester))
+  return render(
+    <MemoryRouter initialEntries={['/tickets']}>
+      <RequesterProvider>
+        <AppRoutes />
+      </RequesterProvider>
+    </MemoryRouter>,
+  )
+}
+
+beforeEach(() => {
+  localStorage.clear()
+})
+
+afterEach(() => {
+  cleanup()
+  vi.unstubAllGlobals()
+  localStorage.clear()
+})
+
+describe('My Tickets states', () => {
+  it('UI-10 (AC-20, BR-30): shows the empty-account state, not filters, when the Requester owns zero Tickets', async () => {
+    mockApi(() => ({ data: [], page: 1, pageSize: 10, totalCount: 0, totalPages: 0, hasAnyTickets: false }))
+    renderMyTickets()
+
+    expect(await screen.findByText(/haven.t created any tickets yet/i)).toBeTruthy()
+    expect(screen.getByRole('link', { name: /create your first ticket/i })).toBeTruthy()
+    expect(screen.queryByPlaceholderText(/search by ticket number or summary/i)).toBeNull()
+  })
+
+  it('UI-11 (AC-19, BR-30): shows the no-results state with Clear Filters, distinct from the empty state', async () => {
+    mockApi(() => ({ data: [], page: 1, pageSize: 10, totalCount: 0, totalPages: 0, hasAnyTickets: true }))
+    renderMyTickets()
+
+    expect(await screen.findByText(/no tickets match your filters/i)).toBeTruthy()
+    expect(screen.queryByText(/haven.t created any tickets yet/i)).toBeNull()
+    expect(screen.getByRole('button', { name: /clear filters/i })).toBeTruthy()
+    // Filters stay visible/interactive in the no-results state (ui-spec §11.3).
+    expect(screen.getByPlaceholderText(/search by ticket number or summary/i)).toBeTruthy()
+  })
+
+  it('UI-12 (AC-18): pagination shows the correct "Showing X to Y of Z" text and Next loads page 2', async () => {
+    const fetchMock = mockApi((url) => {
+      const page = Number(url.searchParams.get('page') ?? '1')
+      if (page === 2) {
+        return {
+          data: [ticket({ id: 2, ticketNumber: 'TKT-2026-000002', summary: 'Second page ticket' })],
+          page: 2,
+          pageSize: 10,
+          totalCount: 11,
+          totalPages: 2,
+          hasAnyTickets: true,
+        }
+      }
+      return {
+        data: Array.from({ length: 10 }, (_, i) =>
+          ticket({ id: i + 1, ticketNumber: `TKT-2026-00000${i + 1}`, summary: `Ticket ${i + 1}` }),
+        ),
+        page: 1,
+        pageSize: 10,
+        totalCount: 11,
+        totalPages: 2,
+        hasAnyTickets: true,
+      }
+    })
+    renderMyTickets()
+
+    expect(await screen.findByText(/showing 1 to 10 of 11 tickets/i)).toBeTruthy()
+    const previousButton = screen.getByRole('button', { name: /^previous$/i }) as HTMLButtonElement
+    expect(previousButton.disabled).toBe(true)
+
+    const user = userEvent.setup()
+    await user.click(screen.getByRole('button', { name: /^next$/i }))
+
+    expect(await screen.findByText(/showing 11 to 11 of 11 tickets/i)).toBeTruthy()
+    expect(within(screen.getByTestId('tickets-table')).getByText('Second page ticket')).toBeTruthy()
+    const calls = fetchMock.mock.calls
+    const lastCall = calls[calls.length - 1][0] as string
+    expect(new URL(lastCall, 'http://localhost').searchParams.get('page')).toBe('2')
+  })
+
+  it('UI-13 (AC-16): typing a search term narrows the list', async () => {
+    mockApi((url) => {
+      const search = url.searchParams.get('search')
+      if (search === 'vpn') {
+        return {
+          data: [ticket({ id: 3, ticketNumber: 'TKT-2026-000003', summary: 'VPN connection drops' })],
+          page: 1,
+          pageSize: 10,
+          totalCount: 1,
+          totalPages: 1,
+          hasAnyTickets: true,
+        }
+      }
+      return {
+        data: [
+          ticket({ id: 1, summary: 'Laptop battery drains quickly' }),
+          ticket({ id: 4, ticketNumber: 'TKT-2026-000004', summary: 'Printer offline' }),
+        ],
+        page: 1,
+        pageSize: 10,
+        totalCount: 2,
+        totalPages: 1,
+        hasAnyTickets: true,
+      }
+    })
+    renderMyTickets()
+
+    await screen.findByTestId('tickets-table')
+    const table = () => within(screen.getByTestId('tickets-table'))
+    table().getByText('Laptop battery drains quickly')
+
+    const user = userEvent.setup()
+    await user.type(screen.getByPlaceholderText(/search by ticket number or summary/i), 'vpn')
+
+    await waitFor(() => expect(table().getByText('VPN connection drops')).toBeTruthy())
+    expect(table().queryByText('Printer offline')).toBeNull()
+  })
+})

--- a/docs/lab-02/tests.md
+++ b/docs/lab-02/tests.md
@@ -48,13 +48,13 @@ is covered by at least one row (§3 matrix).
 | API-03 | API | AC-05 | `POST /api/tickets` description < 10 chars | 400 `VALIDATION_ERROR` field `description`; no row inserted | `server/tests/lab-02/create-ticket.api.test.ts` | Planned |
 | API-04 | API | AC-06 | `POST /api/tickets` missing `requestedPriority` | 400 `VALIDATION_ERROR` field `requestedPriority` | `server/tests/lab-02/create-ticket.api.test.ts` | Planned |
 | API-05 | API | BR-12 | `POST /api/tickets` inactive/unknown `requesterId` | 400 `INVALID_REQUESTER`; no row inserted | `server/tests/lab-02/create-ticket.api.test.ts` | Planned |
-| API-06 | API | AC-03 | `GET /api/tickets` cross-Requester scope | Requester B's list never includes Requester A's tickets | `server/tests/lab-02/my-tickets.api.test.ts` | Planned |
-| API-07 | API | AC-16 | `GET /api/tickets?search=vpn` | Case-insensitive partial match on `ticketNumber`/`summary` only | `server/tests/lab-02/my-tickets.api.test.ts` | Planned |
-| API-08 | API | AC-17 | `GET /api/tickets?categoryId=&status=` | AND-combined filters return only matching rows | `server/tests/lab-02/my-tickets.api.test.ts` | Planned |
-| API-09 | API | AC-18 | `GET /api/tickets` pagination metadata | Correct `page`/`pageSize`/`totalCount`/`totalPages` | `server/tests/lab-02/my-tickets.api.test.ts` | Planned |
-| API-10 | API | BR-19 | `GET /api/tickets` out-of-range `page`/`pageSize` | Clamped to valid bounds, not rejected | `server/tests/lab-02/my-tickets.api.test.ts` | Planned |
-| API-11 | API | AC-20 | `GET /api/tickets` for a Requester with zero tickets | `data: []`, `hasAnyTickets: false` | `server/tests/lab-02/my-tickets.api.test.ts` | Planned |
-| API-12 | API | AC-19 | `GET /api/tickets` filters matching nothing | `data: []`, `hasAnyTickets: true`, `totalCount: 0` | `server/tests/lab-02/my-tickets.api.test.ts` | Planned |
+| API-06 | API | AC-03 | `GET /api/tickets` cross-Requester scope | Requester B's list never includes Requester A's tickets | `server/tests/lab-02/my-tickets.api.test.ts` | Pass |
+| API-07 | API | AC-16 | `GET /api/tickets?search=vpn` | Case-insensitive partial match on `ticketNumber`/`summary` only | `server/tests/lab-02/my-tickets.api.test.ts` | Pass |
+| API-08 | API | AC-17 | `GET /api/tickets?categoryId=&status=` | AND-combined filters return only matching rows | `server/tests/lab-02/my-tickets.api.test.ts` | Pass |
+| API-09 | API | AC-18 | `GET /api/tickets` pagination metadata | Correct `page`/`pageSize`/`totalCount`/`totalPages` | `server/tests/lab-02/my-tickets.api.test.ts` | Pass |
+| API-10 | API | BR-19 | `GET /api/tickets` out-of-range `page`/`pageSize` | Clamped to valid bounds, not rejected | `server/tests/lab-02/my-tickets.api.test.ts` | Pass |
+| API-11 | API | AC-20 | `GET /api/tickets` for a Requester with zero tickets | `data: []`, `hasAnyTickets: false` | `server/tests/lab-02/my-tickets.api.test.ts` | Pass |
+| API-12 | API | AC-19 | `GET /api/tickets` filters matching nothing | `data: []`, `hasAnyTickets: true`, `totalCount: 0` | `server/tests/lab-02/my-tickets.api.test.ts` | Pass |
 | API-13 | API | AC-24 | `GET /api/tickets/:id` owned | 200 with full detail + attachments | `server/tests/lab-02/ticket-detail.api.test.ts` | Planned |
 | API-14 | API | AC-03 | `GET /api/tickets/:id` not owned | 404 `NOT_FOUND` (not 403) | `server/tests/lab-02/ticket-detail.api.test.ts` | Planned |
 | API-15 | API | AC-09 | `POST /api/tickets/:id/attachments` valid 2MB jpg | 201; appears in active attachment list | `server/tests/lab-02/attachments.api.test.ts` | Pass |
@@ -77,10 +77,10 @@ is covered by at least one row (§3 matrix).
 | UI-07 | UI | AC-08 | CreateTicket server failure | Entered values preserved; safe error banner shown | `client/tests/lab-02/CreateTicket.test.tsx` | Pass |
 | UI-08 | UI | AC-01 | CreateTicket success | Generated Ticket Number shown in success state | `client/tests/lab-02/CreateTicket.test.tsx` | Pass |
 | UI-09 | UI | AC-11 | CreateTicket oversized file, client-side | Per-file error shown before any upload request fires | `client/tests/lab-02/CreateTicket.test.tsx` | Pass |
-| UI-10 | UI | AC-20 | MyTickets empty state | Empty-account copy + Create Ticket CTA, no filter UI implying data exists | `client/tests/lab-02/MyTickets.test.tsx` | Planned |
-| UI-11 | UI | AC-19 | MyTickets no-results state | No-results copy + Clear Filters, distinct from empty state | `client/tests/lab-02/MyTickets.test.tsx` | Planned |
-| UI-12 | UI | AC-18 | MyTickets pagination controls | Page navigation updates the list and the "Showing X to Y of Z" text | `client/tests/lab-02/MyTickets.test.tsx` | Planned |
-| UI-13 | UI | AC-16 | MyTickets search input | List filters as the Requester types a search term | `client/tests/lab-02/MyTickets.test.tsx` | Planned |
+| UI-10 | UI | AC-20 | MyTickets empty state | Empty-account copy + Create Ticket CTA, no filter UI implying data exists | `client/tests/lab-02/MyTickets.test.tsx` | Pass |
+| UI-11 | UI | AC-19 | MyTickets no-results state | No-results copy + Clear Filters, distinct from empty state | `client/tests/lab-02/MyTickets.test.tsx` | Pass |
+| UI-12 | UI | AC-18 | MyTickets pagination controls | Page navigation updates the list and the "Showing X to Y of Z" text | `client/tests/lab-02/MyTickets.test.tsx` | Pass |
+| UI-13 | UI | AC-16 | MyTickets search input | List filters as the Requester types a search term | `client/tests/lab-02/MyTickets.test.tsx` | Pass |
 | UI-14 | UI | AC-24 | RequesterTicketDetail read-only rendering | All Ticket fields read-only; no Comment/Status/IT Priority controls present | `client/tests/lab-02/RequesterTicketDetail.test.tsx` | Planned |
 | UI-15 | UI | AC-14, AC-15 | AttachmentSection active vs removed | Active shows Download; removed shows metadata only, no Download action | `client/tests/lab-02/AttachmentSection.test.tsx` | Planned |
 | UI-16 | UI | AC-10 | AttachmentSection at the 5-attachment cap | Upload control shows disabled state with limit explanation | `client/tests/lab-02/AttachmentSection.test.tsx` | Planned |
@@ -166,20 +166,25 @@ npx playwright test e2e/lab-02
 
 ## 6. Final Results
 
-Updated as of Issue 5 (Create Ticket UI). The rows Issue 5 implements —
-UNIT-02, API-15, API-16, API-17, API-18, API-22, API-23, UI-05, UI-06,
-UI-07, UI-08, UI-09, STYLE-01 — are marked `Pass` in §2, confirmed by:
+Updated as of Issue 6 (My Tickets). The rows Issue 6 implements —
+API-06 through API-12, UI-10 through UI-13 — are marked `Pass` in §2,
+confirmed by:
 
 ```bash
-pnpm --filter server test   # 51/51 passing
-pnpm --filter client test   # 49/49 passing
+pnpm --filter server test   # 63/63 passing
+pnpm --filter client test   # 53/53 passing
 ```
 
-Rows owned by other issues (My Tickets, Ticket Detail, attachment
-download/removal, E2E) are still `Planned` and get updated as those
-issues land. STYLE-02 through STYLE-04 and the E2E rows also stay
-`Planned`: they depend on Playwright, which isn't part of this workspace
-yet (§7).
+Also added by Issue 6, beyond the rows tests.md enumerated by name: an
+`INVALID_FILTER` 400 test for an unrecognized `requestedPriority`/`status`/
+`sortBy`/`sortDir` or non-numeric `categoryId` (api-spec.md §5's failure
+table), and a `sortBy=summary` + default-sort-tie-break test (BR-18) — both
+in `my-tickets.api.test.ts` alongside the numbered API-06..12 rows.
+
+Rows owned by other issues (Ticket Detail, attachment download/removal,
+E2E) are still `Planned` and get updated as those issues land. STYLE-02
+through STYLE-04 and the E2E rows also stay `Planned`: they depend on
+Playwright, which isn't part of this workspace yet (§7).
 
 ## 7. Known Limitations or Deferred Tests
 

--- a/server/prisma/seed.ts
+++ b/server/prisma/seed.ts
@@ -28,6 +28,36 @@ const requesters = [
   { name: "Patricia Reyes", email: "patricia.reyes@example.com", isActive: false },
 ];
 
+const STATUS_CYCLE = ["NEW", "OPEN", "IN_PROGRESS", "PENDING", "RESOLVED", "CLOSED", "CANCELLED"] as const;
+const PRIORITY_CYCLE = ["LOW", "MEDIUM", "HIGH"] as const;
+
+// specification.md §7.4: a spread of seeded Tickets per active Requester —
+// enough for one Requester to exceed a page (pagination demo), one
+// Requester with zero Tickets (empty-state demo), and status/priority
+// variety (filter/sort/badge demo). Keyed on ticketNumber so reruns upsert
+// instead of duplicating; the "SEED" marker keeps these apart from any
+// TKT-<year>-<id> row the app itself generates.
+function ticketSpecs(requesterEmail: string, count: number) {
+  return Array.from({ length: count }, (_, i) => ({
+    ticketNumber: `TKT-SEED-${requesterEmail.split("@")[0]}-${String(i + 1).padStart(3, "0")}`,
+    requesterEmail,
+    categoryIndex: i % categories.length,
+    relatedSystemIndex: i % relatedSystems.length,
+    requestedPriority: PRIORITY_CYCLE[i % PRIORITY_CYCLE.length],
+    currentStatus: STATUS_CYCLE[i % STATUS_CYCLE.length],
+    summary: `Sample issue #${i + 1} for seed demo purposes`,
+    description: `This is seeded demo Ticket #${i + 1}, included for filter, sort, and pagination demonstration.`,
+    createdAt: new Date(Date.now() - (count - i) * 24 * 60 * 60 * 1000),
+  }));
+}
+
+const ticketSeeds = [
+  ...ticketSpecs("jennifer.anderson@example.com", 14), // exceeds page 1 at the default page size of 10
+  ...ticketSpecs("michael.brown@example.com", 3),
+  ...ticketSpecs("david.chen@example.com", 5),
+  // siriporn.wattana@example.com deliberately gets zero Tickets (empty-state demo).
+];
+
 async function main() {
   // Re-runnable and convergent: isActive is re-applied so a row deactivated
   // by hand returns to the seeded state, matching the requester loop below.
@@ -54,6 +84,43 @@ async function main() {
       where: { email: requester.email },
       update: { name: requester.name, isActive: requester.isActive },
       create: requester,
+    });
+  }
+
+  const categoryRows = await prisma.category.findMany({ where: { name: { in: categories } } });
+  const relatedSystemRows = await prisma.relatedSystem.findMany({ where: { name: { in: relatedSystems } } });
+  const requesterRows = await prisma.requesterUser.findMany({
+    where: { email: { in: ticketSeeds.map((t) => t.requesterEmail) } },
+  });
+
+  for (const spec of ticketSeeds) {
+    const requester = requesterRows.find((r) => r.email === spec.requesterEmail);
+    const category = categoryRows[spec.categoryIndex];
+    const relatedSystem = relatedSystemRows[spec.relatedSystemIndex];
+    if (!requester || !category || !relatedSystem) continue;
+
+    await prisma.ticket.upsert({
+      where: { ticketNumber: spec.ticketNumber },
+      update: {
+        requesterId: requester.id,
+        categoryId: category.id,
+        relatedSystemId: relatedSystem.id,
+        requestedPriority: spec.requestedPriority,
+        currentStatus: spec.currentStatus,
+        summary: spec.summary,
+        description: spec.description,
+      },
+      create: {
+        ticketNumber: spec.ticketNumber,
+        requesterId: requester.id,
+        categoryId: category.id,
+        relatedSystemId: relatedSystem.id,
+        requestedPriority: spec.requestedPriority,
+        currentStatus: spec.currentStatus,
+        summary: spec.summary,
+        description: spec.description,
+        createdAt: spec.createdAt,
+      },
     });
   }
 }

--- a/server/prisma/seed.ts
+++ b/server/prisma/seed.ts
@@ -1,6 +1,7 @@
 import "dotenv/config";
 import { PrismaPg } from "@prisma/adapter-pg";
 import { PrismaClient } from "../src/generated/prisma/client.js";
+import { formatTicketNumber } from "../src/lib/ticket-number.js";
 
 const adapter = new PrismaPg({ connectionString: process.env.DATABASE_URL });
 const prisma = new PrismaClient({ adapter });
@@ -35,14 +36,14 @@ const PRIORITY_CYCLE = ["LOW", "MEDIUM", "HIGH"] as const;
 // enough for one Requester to exceed a page (pagination demo), one
 // Requester with zero Tickets (empty-state demo), and status/priority
 // variety (filter/sort/badge demo). Keyed on ticketNumber so reruns upsert
-// instead of duplicating; the "SEED" marker keeps these apart from any
-// TKT-<year>-<id> row the app itself generates.
+// instead of duplicating. Category/Related System are carried by name, not
+// array index, so the upsert loop below can't silently reassign them if
+// findMany ever returns those reference rows in a different order.
 function ticketSpecs(requesterEmail: string, count: number) {
   return Array.from({ length: count }, (_, i) => ({
-    ticketNumber: `TKT-SEED-${requesterEmail.split("@")[0]}-${String(i + 1).padStart(3, "0")}`,
     requesterEmail,
-    categoryIndex: i % categories.length,
-    relatedSystemIndex: i % relatedSystems.length,
+    categoryName: categories[i % categories.length],
+    relatedSystemName: relatedSystems[i % relatedSystems.length],
     requestedPriority: PRIORITY_CYCLE[i % PRIORITY_CYCLE.length],
     currentStatus: STATUS_CYCLE[i % STATUS_CYCLE.length],
     summary: `Sample issue #${i + 1} for seed demo purposes`,
@@ -51,12 +52,20 @@ function ticketSpecs(requesterEmail: string, count: number) {
   }));
 }
 
+// BR-06 requires TKT-<year>-<6-digit> even for seed rows (a My Tickets
+// screenshot has to show real-looking Ticket Numbers) — id can't be used
+// since the number has to exist before the row does (upsert key), so a
+// reserved high range (900001+) stands in for it: stable across reruns,
+// obviously synthetic, still spec-shaped.
 const ticketSeeds = [
   ...ticketSpecs("jennifer.anderson@example.com", 14), // exceeds page 1 at the default page size of 10
   ...ticketSpecs("michael.brown@example.com", 3),
   ...ticketSpecs("david.chen@example.com", 5),
   // siriporn.wattana@example.com deliberately gets zero Tickets (empty-state demo).
-];
+].map((spec, i) => ({
+  ...spec,
+  ticketNumber: formatTicketNumber(900001 + i, spec.createdAt.getFullYear()),
+}));
 
 async function main() {
   // Re-runnable and convergent: isActive is re-applied so a row deactivated
@@ -87,24 +96,33 @@ async function main() {
     });
   }
 
-  const categoryRows = await prisma.category.findMany({ where: { name: { in: categories } } });
-  const relatedSystemRows = await prisma.relatedSystem.findMany({ where: { name: { in: relatedSystems } } });
+  const categoryRows = await prisma.category.findMany({
+    where: { name: { in: categories } },
+    orderBy: { name: "asc" },
+  });
+  const relatedSystemRows = await prisma.relatedSystem.findMany({
+    where: { name: { in: relatedSystems } },
+    orderBy: { name: "asc" },
+  });
   const requesterRows = await prisma.requesterUser.findMany({
     where: { email: { in: ticketSeeds.map((t) => t.requesterEmail) } },
   });
 
+  const categoryIdByName = new Map(categoryRows.map((c) => [c.name, c.id]));
+  const relatedSystemIdByName = new Map(relatedSystemRows.map((s) => [s.name, s.id]));
+
   for (const spec of ticketSeeds) {
     const requester = requesterRows.find((r) => r.email === spec.requesterEmail);
-    const category = categoryRows[spec.categoryIndex];
-    const relatedSystem = relatedSystemRows[spec.relatedSystemIndex];
-    if (!requester || !category || !relatedSystem) continue;
+    const categoryId = categoryIdByName.get(spec.categoryName);
+    const relatedSystemId = relatedSystemIdByName.get(spec.relatedSystemName);
+    if (!requester || categoryId === undefined || relatedSystemId === undefined) continue;
 
     await prisma.ticket.upsert({
       where: { ticketNumber: spec.ticketNumber },
       update: {
         requesterId: requester.id,
-        categoryId: category.id,
-        relatedSystemId: relatedSystem.id,
+        categoryId,
+        relatedSystemId,
         requestedPriority: spec.requestedPriority,
         currentStatus: spec.currentStatus,
         summary: spec.summary,
@@ -113,8 +131,8 @@ async function main() {
       create: {
         ticketNumber: spec.ticketNumber,
         requesterId: requester.id,
-        categoryId: category.id,
-        relatedSystemId: relatedSystem.id,
+        categoryId,
+        relatedSystemId,
         requestedPriority: spec.requestedPriority,
         currentStatus: spec.currentStatus,
         summary: spec.summary,

--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -162,6 +162,128 @@ app.post('/api/tickets', async (req, res) => {
   res.status(201).json(ticket)
 })
 
+const SORTABLE_FIELDS = ['createdAt', 'ticketNumber', 'summary', 'requestedPriority', 'currentStatus'] as const
+const STATUSES = ['NEW', 'OPEN', 'IN_PROGRESS', 'PENDING', 'RESOLVED', 'CLOSED', 'CANCELLED']
+const DEFAULT_PAGE_SIZE = 10
+const MAX_PAGE_SIZE = 50
+
+function clampPage(raw: unknown): number {
+  const n = Number(raw)
+  return Number.isInteger(n) && n > 0 ? n : 1
+}
+
+function clampPageSize(raw: unknown): number {
+  if (raw === undefined) return DEFAULT_PAGE_SIZE
+  const n = Number(raw)
+  if (!Number.isInteger(n)) return DEFAULT_PAGE_SIZE
+  return Math.min(Math.max(n, 1), MAX_PAGE_SIZE)
+}
+
+// api-spec.md §5 (FR-05..09, BR-14, BR-16..19). Ownership (BR-14) scopes
+// every query; filters combine with AND (BR-17); page/pageSize are clamped
+// rather than rejected (BR-19), everything else invalid is a 400.
+app.get('/api/tickets', async (req, res) => {
+  const requester = await resolveActiveRequester(req)
+  if (!requester) {
+    return res.status(400).json({
+      error: { code: 'INVALID_REQUESTER', message: 'Requester is missing, unknown, or inactive.' },
+    })
+  }
+
+  const where: Prisma.TicketWhereInput = { requesterId: requester.id }
+
+  if (req.query.categoryId !== undefined) {
+    const categoryId = Number(req.query.categoryId)
+    if (!Number.isInteger(categoryId)) {
+      return res.status(400).json({
+        error: { code: 'INVALID_FILTER', message: 'categoryId must be an integer.', field: 'categoryId' },
+      })
+    }
+    where.categoryId = categoryId
+  }
+
+  if (req.query.requestedPriority !== undefined) {
+    if (!PRIORITIES.includes(req.query.requestedPriority as string)) {
+      return res.status(400).json({
+        error: {
+          code: 'INVALID_FILTER',
+          message: 'requestedPriority must be LOW, MEDIUM, or HIGH.',
+          field: 'requestedPriority',
+        },
+      })
+    }
+    where.requestedPriority = req.query.requestedPriority as Prisma.TicketWhereInput['requestedPriority']
+  }
+
+  if (req.query.status !== undefined) {
+    if (!STATUSES.includes(req.query.status as string)) {
+      return res.status(400).json({
+        error: { code: 'INVALID_FILTER', message: 'status is not a recognized Current Status.', field: 'status' },
+      })
+    }
+    where.currentStatus = req.query.status as Prisma.TicketWhereInput['currentStatus']
+  }
+
+  if (typeof req.query.search === 'string' && req.query.search.trim() !== '') {
+    const search = req.query.search.trim()
+    where.OR = [
+      { ticketNumber: { contains: search, mode: 'insensitive' } },
+      { summary: { contains: search, mode: 'insensitive' } },
+    ]
+  }
+
+  const sortBy = req.query.sortBy === undefined ? 'createdAt' : (req.query.sortBy as string)
+  if (!(SORTABLE_FIELDS as readonly string[]).includes(sortBy)) {
+    return res.status(400).json({
+      error: { code: 'INVALID_FILTER', message: 'sortBy is not a recognized column.', field: 'sortBy' },
+    })
+  }
+
+  const sortDir = req.query.sortDir === undefined ? 'desc' : (req.query.sortDir as string)
+  if (sortDir !== 'asc' && sortDir !== 'desc') {
+    return res.status(400).json({
+      error: { code: 'INVALID_FILTER', message: 'sortDir must be asc or desc.', field: 'sortDir' },
+    })
+  }
+
+  const page = clampPage(req.query.page)
+  const pageSize = clampPageSize(req.query.pageSize)
+
+  const [totalCount, hasAnyTickets, data] = await Promise.all([
+    prisma.ticket.count({ where }),
+    prisma.ticket.count({ where: { requesterId: requester.id }, take: 1 }).then((c) => c > 0),
+    prisma.ticket.findMany({
+      where,
+      // A single sort key is not enough to make pagination deterministic
+      // when rows tie on it (api-spec.md §5 doesn't name a tie-break); id
+      // in the same direction gives every page a stable, repeatable order.
+      orderBy: [{ [sortBy]: sortDir }, { id: sortDir }],
+      skip: (page - 1) * pageSize,
+      take: pageSize,
+      include: { category: { select: { name: true } } },
+    }),
+  ])
+
+  res.json({
+    data: data.map((t) => ({
+      id: t.id,
+      ticketNumber: t.ticketNumber,
+      summary: t.summary,
+      categoryId: t.categoryId,
+      categoryName: t.category.name,
+      requestedPriority: t.requestedPriority,
+      currentStatus: t.currentStatus,
+      createdAt: t.createdAt,
+      updatedAt: t.updatedAt,
+    })),
+    page,
+    pageSize,
+    totalCount,
+    totalPages: Math.ceil(totalCount / pageSize),
+    hasAnyTickets,
+  })
+})
+
 class UnsupportedFileTypeError extends Error {}
 class AttachmentLimitReachedError extends Error {}
 

--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -192,11 +192,12 @@ app.get('/api/tickets', async (req, res) => {
 
   const where: Prisma.TicketWhereInput = { requesterId: requester.id }
 
-  if (req.query.categoryId !== undefined) {
+  if (typeof req.query.categoryId === 'string' && req.query.categoryId.trim() !== '') {
     const categoryId = Number(req.query.categoryId)
-    if (!Number.isInteger(categoryId)) {
+    const category = Number.isInteger(categoryId) ? await prisma.category.findUnique({ where: { id: categoryId } }) : null
+    if (!category) {
       return res.status(400).json({
-        error: { code: 'INVALID_FILTER', message: 'categoryId must be an integer.', field: 'categoryId' },
+        error: { code: 'INVALID_FILTER', message: 'categoryId does not reference a known Category.', field: 'categoryId' },
       })
     }
     where.categoryId = categoryId

--- a/server/tests/lab-02/my-tickets.api.test.ts
+++ b/server/tests/lab-02/my-tickets.api.test.ts
@@ -222,18 +222,26 @@ describe('GET /api/tickets', () => {
     expect(t12Index).toBeLessThan(t11Index)
   })
 
-  it('rejects an unrecognized requestedPriority/status/sortBy/sortDir/non-numeric categoryId with 400 INVALID_FILTER', async () => {
+  it('rejects an unrecognized requestedPriority/status/sortBy/sortDir/non-numeric or unknown categoryId with 400 INVALID_FILTER', async () => {
     const cases = [
       { requestedPriority: 'URGENT' },
       { status: 'DELETED' },
       { sortBy: 'notAField' },
       { sortDir: 'sideways' },
       { categoryId: 'abc' },
+      { categoryId: -999 },
     ]
     for (const invalid of cases) {
       const res = await request(app).get('/api/tickets').query({ requesterId: requesterAId, ...invalid })
       expect(res.status).toBe(400)
       expect(res.body.error.code).toBe('INVALID_FILTER')
     }
+  })
+
+  it('treats an empty categoryId as no filter rather than category 0', async () => {
+    const res = await request(app).get('/api/tickets').query({ requesterId: requesterAId, categoryId: '', pageSize: 50 })
+
+    expect(res.status).toBe(200)
+    expect(res.body.totalCount).toBe(12)
   })
 })

--- a/server/tests/lab-02/my-tickets.api.test.ts
+++ b/server/tests/lab-02/my-tickets.api.test.ts
@@ -1,0 +1,239 @@
+import request from 'supertest'
+import { afterAll, beforeAll, describe, expect, it } from 'vitest'
+import { app } from '../../src/app.js'
+import { prisma } from '../../src/db.js'
+
+// API-06..12 (AC-03, AC-16, AC-17, AC-18, AC-19, AC-20; BR-14, BR-16, BR-17,
+// BR-18, BR-19, BR-30) plus INVALID_FILTER/sort-by-column coverage that
+// tests.md's table doesn't break into its own row but api-spec.md §5 and
+// BR-18 require.
+
+const TAG = 'my-tickets.test'
+
+let requesterAId: number
+let requesterBId: number
+let requesterCId: number // owns zero tickets (API-11/AC-20)
+let catXId: number
+let catYId: number
+let relatedSystemId: number
+
+type Seed = {
+  summary: string
+  categoryId: () => number
+  requestedPriority: 'LOW' | 'MEDIUM' | 'HIGH'
+  currentStatus: 'NEW' | 'OPEN' | 'IN_PROGRESS' | 'PENDING' | 'RESOLVED' | 'CLOSED' | 'CANCELLED'
+  createdAt: string
+}
+
+const ticketIds: Record<string, number> = {}
+
+async function wipe() {
+  await prisma.ticket.deleteMany({
+    where: { requesterId: { in: [requesterAId, requesterBId, requesterCId].filter(Boolean) } },
+  })
+  await prisma.requesterUser.deleteMany({ where: { email: { contains: TAG } } })
+  await prisma.category.deleteMany({ where: { name: { contains: TAG } } })
+  await prisma.relatedSystem.deleteMany({ where: { name: { contains: TAG } } })
+}
+
+beforeAll(async () => {
+  const requesterA = await prisma.requesterUser.create({
+    data: { name: 'Requester A', email: `a.${TAG}`, isActive: true },
+  })
+  const requesterB = await prisma.requesterUser.create({
+    data: { name: 'Requester B', email: `b.${TAG}`, isActive: true },
+  })
+  const requesterC = await prisma.requesterUser.create({
+    data: { name: 'Requester C', email: `c.${TAG}`, isActive: true },
+  })
+  requesterAId = requesterA.id
+  requesterBId = requesterB.id
+  requesterCId = requesterC.id
+
+  const catX = await prisma.category.create({ data: { name: `Category X ${TAG}` } })
+  const catY = await prisma.category.create({ data: { name: `Category Y ${TAG}` } })
+  catXId = catX.id
+  catYId = catY.id
+
+  const relatedSystem = await prisma.relatedSystem.create({ data: { name: `System ${TAG}` } })
+  relatedSystemId = relatedSystem.id
+
+  const seeds: Record<string, Seed> = {
+    T1: { summary: 'VPN connection drops constantly', categoryId: () => catXId, requestedPriority: 'HIGH', currentStatus: 'OPEN', createdAt: '2026-01-01T10:00:00.000Z' },
+    T2: { summary: 'Printer not responding', categoryId: () => catYId, requestedPriority: 'LOW', currentStatus: 'NEW', createdAt: '2026-01-02T10:00:00.000Z' },
+    T3: { summary: 'Laptop battery drains fast', categoryId: () => catXId, requestedPriority: 'MEDIUM', currentStatus: 'IN_PROGRESS', createdAt: '2026-01-03T10:00:00.000Z' },
+    T4: { summary: 'Wifi intermittent vpn drops', categoryId: () => catYId, requestedPriority: 'HIGH', currentStatus: 'OPEN', createdAt: '2026-01-04T10:00:00.000Z' },
+    T5: { summary: 'Email sync delayed', categoryId: () => catXId, requestedPriority: 'LOW', currentStatus: 'PENDING', createdAt: '2026-01-05T10:00:00.000Z' },
+    T6: { summary: 'Account locked out', categoryId: () => catYId, requestedPriority: 'MEDIUM', currentStatus: 'RESOLVED', createdAt: '2026-01-06T10:00:00.000Z' },
+    T7: { summary: 'Software crash on save', categoryId: () => catXId, requestedPriority: 'HIGH', currentStatus: 'CLOSED', createdAt: '2026-01-07T10:00:00.000Z' },
+    T8: { summary: 'Network drop in building B', categoryId: () => catYId, requestedPriority: 'LOW', currentStatus: 'CANCELLED', createdAt: '2026-01-08T10:00:00.000Z' },
+    T9: { summary: 'Monitor flickering', categoryId: () => catXId, requestedPriority: 'MEDIUM', currentStatus: 'NEW', createdAt: '2026-01-09T10:00:00.000Z' },
+    T10: { summary: 'Keyboard keys sticking', categoryId: () => catYId, requestedPriority: 'HIGH', currentStatus: 'OPEN', createdAt: '2026-01-10T10:00:00.000Z' },
+    T11: { summary: 'Slow laptop performance', categoryId: () => catXId, requestedPriority: 'LOW', currentStatus: 'NEW', createdAt: '2026-01-11T10:00:00.000Z' },
+    T12: { summary: 'Password reset needed', categoryId: () => catYId, requestedPriority: 'MEDIUM', currentStatus: 'NEW', createdAt: '2026-01-11T10:00:00.000Z' }, // same createdAt as T11 (tie-break)
+  }
+
+  for (const [key, seed] of Object.entries(seeds)) {
+    const created = await prisma.ticket.create({
+      data: {
+        ticketNumber: `TKT-TEST-${TAG}-${key}`,
+        requesterId: requesterAId,
+        categoryId: seed.categoryId(),
+        relatedSystemId,
+        summary: seed.summary,
+        description: `${seed.summary} — fixture description long enough to pass validation minimums.`,
+        requestedPriority: seed.requestedPriority,
+        currentStatus: seed.currentStatus,
+        createdAt: new Date(seed.createdAt),
+      },
+    })
+    ticketIds[key] = created.id
+  }
+
+  // Requester B: one ticket, used only to prove isolation from Requester A's list.
+  await prisma.ticket.create({
+    data: {
+      ticketNumber: `TKT-TEST-${TAG}-B1`,
+      requesterId: requesterBId,
+      categoryId: catXId,
+      relatedSystemId,
+      summary: 'Requester B ticket, must never appear in A list',
+      description: 'Fixture description long enough to pass validation minimums.',
+      requestedPriority: 'MEDIUM',
+      currentStatus: 'NEW',
+    },
+  })
+})
+
+afterAll(wipe)
+
+describe('GET /api/tickets', () => {
+  it('API-06 (AC-03, BR-14): returns only the requesterId owner’s tickets, never another Requester’s', async () => {
+    const res = await request(app).get('/api/tickets').query({ requesterId: requesterAId, pageSize: 50 })
+
+    expect(res.status).toBe(200)
+    expect(res.body.totalCount).toBe(12)
+    const summaries = res.body.data.map((t: { summary: string }) => t.summary)
+    expect(summaries).not.toContain('Requester B ticket, must never appear in A list')
+  })
+
+  it('API-11 (AC-20, BR-30): a Requester with zero tickets gets data: [] and hasAnyTickets: false', async () => {
+    const res = await request(app).get('/api/tickets').query({ requesterId: requesterCId })
+
+    expect(res.status).toBe(200)
+    expect(res.body.data).toEqual([])
+    expect(res.body.hasAnyTickets).toBe(false)
+    expect(res.body.totalCount).toBe(0)
+  })
+
+  it('rejects an unknown/inactive requesterId with 400 INVALID_REQUESTER', async () => {
+    const res = await request(app).get('/api/tickets').query({ requesterId: -999 })
+
+    expect(res.status).toBe(400)
+    expect(res.body.error.code).toBe('INVALID_REQUESTER')
+  })
+
+  it('API-07 (AC-16, BR-16): search matches ticketNumber or summary, case-insensitive, partial', async () => {
+    const res = await request(app).get('/api/tickets').query({ requesterId: requesterAId, search: 'vpn' })
+
+    expect(res.status).toBe(200)
+    const summaries = res.body.data.map((t: { summary: string }) => t.summary).sort()
+    expect(summaries).toEqual(['VPN connection drops constantly', 'Wifi intermittent vpn drops'])
+  })
+
+  it('API-08 (AC-17, BR-17): categoryId + status filters combine with AND logic', async () => {
+    const res = await request(app)
+      .get('/api/tickets')
+      .query({ requesterId: requesterAId, categoryId: catXId, status: 'OPEN' })
+
+    expect(res.status).toBe(200)
+    expect(res.body.data).toHaveLength(1)
+    expect(res.body.data[0].summary).toBe('VPN connection drops constantly')
+  })
+
+  it('API-12 (AC-19, BR-30): filters matching nothing return data: [] with hasAnyTickets: true, totalCount: 0', async () => {
+    const res = await request(app)
+      .get('/api/tickets')
+      .query({ requesterId: requesterAId, search: 'no-such-ticket-summary-anywhere' })
+
+    expect(res.status).toBe(200)
+    expect(res.body.data).toEqual([])
+    expect(res.body.hasAnyTickets).toBe(true)
+    expect(res.body.totalCount).toBe(0)
+  })
+
+  it('API-09 (AC-18): pagination metadata is correct and page 1 shows only the default page size', async () => {
+    const res = await request(app).get('/api/tickets').query({ requesterId: requesterAId })
+
+    expect(res.status).toBe(200)
+    expect(res.body.data).toHaveLength(10)
+    expect(res.body.page).toBe(1)
+    expect(res.body.pageSize).toBe(10)
+    expect(res.body.totalCount).toBe(12)
+    expect(res.body.totalPages).toBe(2)
+  })
+
+  it('API-09: page 2 shows the remaining tickets', async () => {
+    const res = await request(app).get('/api/tickets').query({ requesterId: requesterAId, page: 2 })
+
+    expect(res.status).toBe(200)
+    expect(res.body.data).toHaveLength(2)
+  })
+
+  it('API-10 (BR-19): out-of-range page/pageSize are clamped, not rejected', async () => {
+    const zeroPage = await request(app).get('/api/tickets').query({ requesterId: requesterAId, page: 0 })
+    expect(zeroPage.status).toBe(200)
+    expect(zeroPage.body.page).toBe(1)
+
+    const negativePage = await request(app).get('/api/tickets').query({ requesterId: requesterAId, page: -5 })
+    expect(negativePage.status).toBe(200)
+    expect(negativePage.body.page).toBe(1)
+
+    const oversizedPageSize = await request(app)
+      .get('/api/tickets')
+      .query({ requesterId: requesterAId, pageSize: 1000 })
+    expect(oversizedPageSize.status).toBe(200)
+    expect(oversizedPageSize.body.pageSize).toBe(50)
+
+    const zeroPageSize = await request(app).get('/api/tickets').query({ requesterId: requesterAId, pageSize: 0 })
+    expect(zeroPageSize.status).toBe(200)
+    expect(zeroPageSize.body.pageSize).toBe(1)
+  })
+
+  it('BR-18: sortBy=summary asc sorts alphabetically by Summary', async () => {
+    const res = await request(app)
+      .get('/api/tickets')
+      .query({ requesterId: requesterAId, sortBy: 'summary', sortDir: 'asc', pageSize: 50 })
+
+    expect(res.status).toBe(200)
+    const summaries = res.body.data.map((t: { summary: string }) => t.summary)
+    expect(summaries).toEqual([...summaries].sort())
+  })
+
+  it('BR-18: default sort is createdAt desc, with id desc as a deterministic tie-break', async () => {
+    const res = await request(app).get('/api/tickets').query({ requesterId: requesterAId, pageSize: 50 })
+
+    expect(res.status).toBe(200)
+    // T11 and T12 share the same createdAt; T12 was inserted after T11, so
+    // its id is higher, and the tie-break must put it first under a desc sort.
+    const numbers = res.body.data.map((t: { ticketNumber: string }) => t.ticketNumber)
+    const t11Index = numbers.indexOf(`TKT-TEST-${TAG}-T11`)
+    const t12Index = numbers.indexOf(`TKT-TEST-${TAG}-T12`)
+    expect(t12Index).toBeLessThan(t11Index)
+  })
+
+  it('rejects an unrecognized requestedPriority/status/sortBy/sortDir/non-numeric categoryId with 400 INVALID_FILTER', async () => {
+    const cases = [
+      { requestedPriority: 'URGENT' },
+      { status: 'DELETED' },
+      { sortBy: 'notAField' },
+      { sortDir: 'sideways' },
+      { categoryId: 'abc' },
+    ]
+    for (const invalid of cases) {
+      const res = await request(app).get('/api/tickets').query({ requesterId: requesterAId, ...invalid })
+      expect(res.status).toBe(400)
+      expect(res.body.error.code).toBe('INVALID_FILTER')
+    }
+  })
+})


### PR DESCRIPTION
## Summary

Implements Issue #21 (My Tickets): the Requester-owned ticket list screen and its backing API.

`GET /api/tickets` supports search, filtering by Category, Requested Priority, and Current Status (AND-combined), sorting, and pagination. It returns `hasAnyTickets` so the client can tell an empty account apart from a search or filter that just has no matches. Ownership is enforced server-side, scoping every query to the caller's `requesterId`, not by filtering on the client.

The My Tickets screen has a search box, the filters above, sortable columns, pagination controls, a Clear Filters action, and a Create Ticket action. It renders as a table on desktop and a card list on mobile, and covers loading, empty, no-results, and failure states, plus priority and status badges.

I also added ticket seed data (multiple statuses and priorities, one Requester past page 1, one Requester with zero tickets) so the screen has something real to demo against, and fixed a pre-existing CSS bug where a `<Link>` styled as `.zg-btn` rendered underlined instead of looking like a button. That fix also cleans up Create Ticket's View Ticket button.

## Test plan

`pnpm --filter server test`: 63/63 passing, 12 new (ownership isolation, search, filters, sort plus a tie-break, pagination and clamping, invalid-filter 400s, empty vs. no-results).

`pnpm --filter client test`: 53/53 passing, 4 new (empty state, no-results state, pagination, search).

`tsc -b` on the client and `tsc --noEmit` on the server are both clean, and so is `oxlint`.

## Deviations and assumptions worth a second look

The column set follows `ui-spec.md` §11.3 exactly: Ticket No., Created Date, Summary, Category, Requested Priority, Current Status, Last Updated. No IT Priority or Ticket Owner columns, since neither exists in the Lab 2 schema or API response.

I added an `id` sort tie-break. `api-spec.md` doesn't specify one, and without it, rows sharing a `createdAt` could shift page or show up twice across page loads.

Badge icons for the two status pairs that share a color (Pending/In Progress, Cancelled/Closed) are my pick: hourglass-split, arrow-repeat, x-circle, check2-circle.

No responsive screenshots yet. Playwright still isn't an installed dependency, and `tests.md` §7 defers that setup to a separate E2E issue.

Addresses #21
